### PR TITLE
Changing config location for sidecar builds

### DIFF
--- a/Source/Shared/WinRT/local_config_winrt.cpp
+++ b/Source/Shared/WinRT/local_config_winrt.cpp
@@ -30,9 +30,14 @@ xbox_live_result<void> local_config::read()
         return xbox_live_result<void>();
     }
 
+#if XSAPI_SIDECAR
+    string_t configPath = _T("xboxservices.config");
+#else
     Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
     Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
     string_t configPath = string_t(installedLocation->Path->Data()) + _T("\\xboxservices.config");
+#endif
+
 
     string_t fileData = utils::read_file_to_string(configPath);
     if( !fileData.empty() )


### PR DESCRIPTION
For sidecar executables (unity editor, for example), there's no package directory, since they are win32 apps.  For those executables, use the current working directory as the root for loading the config file.