### PR TITLE
Fixing issue with sidecar protocol activation code

### DIFF
--- a/Source/System/Sidecar/app_service_client.cpp
+++ b/Source/System/Sidecar/app_service_client.cpp
@@ -233,8 +233,12 @@ namespace app_service {
 				}
 
                 REQUEST message = { requestTracker->request_id(), params... };
+
+                Platform::String^ protocolUrl = m_appChannelName + "://";
+                Windows::Foundation::Uri^ uri = ref new Windows::Foundation::Uri(protocolUrl);
+
 				auto createWindowTask = uiMode == ui_mode::allowed ?
-					concurrency::create_task(Windows::System::Launcher::LaunchUriAsync(ref new Windows::Foundation::Uri(m_appChannelName))) :
+					concurrency::create_task(Windows::System::Launcher::LaunchUriAsync(uri)) :
 					task_from_result(true);
 
 				return createWindowTask


### PR DESCRIPTION
missed the '://' when I changed from hard-coded to using the config file.  