### PR TITLE
Fixes for include files and error handling during sidecar token fetch

### DIFF
--- a/Include/xsapi/system.h
+++ b/Include/xsapi/system.h
@@ -9,7 +9,6 @@
 //*********************************************************
 #pragma once
 
-#include "pch.h"
 #include "types.h"
 #include "errors.h"
 #include "xbox_live_context_settings.h"

--- a/Include/xsapi/xbox_service_call_routed_event_args.h
+++ b/Include/xsapi/xbox_service_call_routed_event_args.h
@@ -8,7 +8,6 @@
 //
 //*********************************************************
 #pragma once
-#include "pch.h"
 #include "xsapi/http_call_request_message.h"
 
 NAMESPACE_MICROSOFT_XBOX_SERVICES_CPP_BEGIN

--- a/Source/Shared/shared_macros.h
+++ b/Source/Shared/shared_macros.h
@@ -8,7 +8,6 @@
 //
 //*********************************************************
 #pragma once
-#include "pch.h"
 #include "build_version.h"
 
 #ifndef UNIT_TEST_SERVICES

--- a/Source/System/Sidecar/app_service_messages.cpp
+++ b/Source/System/Sidecar/app_service_messages.cpp
@@ -78,7 +78,12 @@ inline typename std::enable_if<std::is_same<T, string_t>::value, T>::type deseri
 #define APP_SERVICE_MESSAGE(type) \
 	_Use_decl_annotations_ xbox_live_result<type> type::from_service_message(Windows::Foundation::Collections::ValueSet ^message) \
 	{ \
-		Platform::String ^messageType = safe_cast<Platform::String^>(message->Lookup(L"message_type")); \
+		Platform::String ^messageType = L""; \
+        if (message->HasKey(L"message_type")) \
+        { \
+            messageType = safe_cast<Platform::String^>(message->Lookup(L"message_type")); \
+        } \
+        \
 		if (message->HasKey(L"err")) \
 		{ \
 			return xbox_live_result<type>( \


### PR DESCRIPTION
Fixing a few places where pch.h was included in headers.

Fixing a bug when an error occurred during token fetch via the sidecar appchannel