### PR TITLE
Enable updated MPSD Thunderhead allocation method

### DIFF
--- a/Include/xsapi/multiplayer.h
+++ b/Include/xsapi/multiplayer.h
@@ -1200,7 +1200,8 @@ public:
         _In_ uint32_t maxMembersInSession,
         _In_ multiplayer_session_visibility visibility,
         _In_ std::vector<string_t> initiatorXboxIds,
-        _In_ web::json::value sessionCustomConstants
+        _In_ web::json::value sessionCustomConstants,
+        _In_ web::json::value sessionCloudComputePackageConstants
         );
 
     /// <summary>
@@ -1239,6 +1240,11 @@ public:
     /// JSON string that specify the custom constants for the session.  These can not be changed after the session is created. (Optional)
     /// </summary>
     _XSAPIIMP const web::json::value& session_custom_constants_json() const;
+
+    /// <summary>
+    /// JSON string that specify the cloud compute package constants for the session.  These can not be changed after the session is created. (Optional)
+    /// </summary>
+    _XSAPIIMP const web::json::value& session_cloud_compute_package_constants_json() const;
 
     /// <summary>
     /// If a member reservation does not join within this timeout, then reservation is removed.
@@ -1485,6 +1491,7 @@ private:
     multiplayer_session_visibility m_visibility;
     std::vector<string_t> m_initiatorXboxUserIds;
     web::json::value m_sessionCustomConstants;
+    web::json::value m_sessionCloudComputePackageConstants;
     multiplayer_session_capabilities m_sessionCapabilities;
 
     // Arbitration timeouts
@@ -2665,6 +2672,12 @@ public:
     _XSAPIIMP bool closed() const;
 
     /// <summary>
+    /// Setting to true by a client triggers a Thunderhead allocation attempt by MPSD.
+    /// Defaults to false.
+    /// </summary>
+    _XSAPIIMP bool allocate_cloud_compute() const;
+
+    /// <summary>
     /// Internal function
     /// </summary>
     void _Initialize(
@@ -2724,6 +2737,7 @@ private:
     std::vector<string_t> m_serverConnectionStringCandidates;
 
     bool m_closed;
+    bool m_allocateCloudCompute;
 
     static std::mutex m_lock;
 };
@@ -2785,7 +2799,8 @@ public:
         _In_ uint32_t maxMembersInSession,
         _In_ multiplayer_session_visibility multiplayerSessionVisibility,
         _In_ std::vector<string_t> initiatorXboxUserIds = std::vector<string_t>(),
-        _In_ web::json::value sessionCustomConstantsJson = web::json::value()
+        _In_ web::json::value sessionCustomConstantsJson = web::json::value(),
+        _In_ web::json::value sessionCloudComputePackageConstantsJson = web::json::value()
         );
 
     /// <summary>
@@ -3184,6 +3199,15 @@ public:
     /// </summary>
     _XSAPIIMP void set_closed(
         _In_ bool closed
+        );
+
+    /// <summary>
+    /// Call multiplayer_service::write_session after this to write batched local changes to the service. 
+    /// If this is called without multiplayer_service::write_session, this will only change the local session object but does not commit it to the service.
+    /// If set to true, makes the session "closed", meaning that new users will not be able to join unless they already have a reservation.
+    /// </summary>
+    _XSAPIIMP void set_allocate_cloud_compute(
+        _In_ bool allocateCloudCompute
         );
 
     /// <summary>

--- a/Source/Services/Multiplayer/WinRT/MultiplayerSessionProperties_WinRT.h
+++ b/Source/Services/Multiplayer/WinRT/MultiplayerSessionProperties_WinRT.h
@@ -157,6 +157,13 @@ public:
     /// </summary>
     DEFINE_PTR_PROP_GET_OBJ(Closed, closed, bool);
 
+    /// <summary>
+    /// A value that indicates if there is an outstanding request to allocate.
+    /// Set to true to indicate that the client would like an allocation. Set to false to cancel the allocation request.
+    /// MPSD will remove this property entirely if the allocation has failed.
+    /// </summary>
+    DEFINE_PTR_PROP_GET_OBJ(AllocateCloudCompute, allocate_cloud_compute, bool);
+
 internal:
     MultiplayerSessionProperties(
         std::shared_ptr<xbox::services::multiplayer::multiplayer_session_properties> cppObj

--- a/Source/Services/Multiplayer/WinRT/MultiplayerSession_WinRT.cpp
+++ b/Source/Services/Multiplayer/WinRT/MultiplayerSession_WinRT.cpp
@@ -53,11 +53,12 @@ MultiplayerSession::MultiplayerSession(
     _In_ bool reserved,
     _In_ MultiplayerSessionVisibility multiplayerSessionVisibility,
     _In_opt_ Windows::Foundation::Collections::IVectorView<Platform::String^>^ initiatorXboxUserIds,
-    _In_opt_ Platform::String^ sessionCustomConstantsJson
+    _In_opt_ Platform::String^ sessionCustomConstantsJson,
+    _In_opt_ Platform::String^ sessionCloudComputePackageConstantsJson
     )
 {
     UNREFERENCED_PARAMETER(reserved);
-    _Init(xboxLiveContext, multiplayerSessionReference, maxMembersInSession, multiplayerSessionVisibility, initiatorXboxUserIds, sessionCustomConstantsJson);
+    _Init(xboxLiveContext, multiplayerSessionReference, maxMembersInSession, multiplayerSessionVisibility, initiatorXboxUserIds, sessionCustomConstantsJson, sessionCloudComputePackageConstantsJson);
 }
 #endif
 
@@ -67,10 +68,11 @@ MultiplayerSession::MultiplayerSession(
     _In_ uint32 maxMembersInSession,
     _In_ MultiplayerSessionVisibility multiplayerSessionVisibility,
     _In_opt_ Windows::Foundation::Collections::IVectorView<Platform::String^>^ initiatorXboxUserIds,
-    _In_opt_ Platform::String^ sessionCustomConstantsJson
+    _In_opt_ Platform::String^ sessionCustomConstantsJson,
+    _In_opt_ Platform::String^ sessionCloudComputePackageConstantsJson
     )
 {
-    _Init(xboxLiveContext, multiplayerSessionReference, maxMembersInSession, multiplayerSessionVisibility, initiatorXboxUserIds, sessionCustomConstantsJson);
+    _Init(xboxLiveContext, multiplayerSessionReference, maxMembersInSession, multiplayerSessionVisibility, initiatorXboxUserIds, sessionCustomConstantsJson, sessionCloudComputePackageConstantsJson);
 }
 
 void
@@ -80,7 +82,8 @@ MultiplayerSession::_Init(
     _In_ uint32 maxMembersInSession,
     _In_ MultiplayerSessionVisibility multiplayerSessionVisibility,
     _In_opt_ Windows::Foundation::Collections::IVectorView<Platform::String^>^ initiatorXboxUserIds,
-    _In_opt_ Platform::String^ sessionCustomConstantsJson
+    _In_opt_ Platform::String^ sessionCustomConstantsJson,
+    _In_opt_ Platform::String^ sessionCloudComputePackageConstantsJson
     )
 {
     THROW_INVALIDARGUMENT_IF_NULL(xboxLiveContext);
@@ -94,13 +97,15 @@ MultiplayerSession::_Init(
 
     CONVERT_STD_EXCEPTION(
         auto sessionCustomConstantsValueString = UtilsWinRT::JsonValueFromPlatformString(sessionCustomConstantsJson);
+        auto sessionCloudComputePackageConstantsValueString = UtilsWinRT::JsonValueFromPlatformString(sessionCloudComputePackageConstantsJson);
         m_cppObj = std::make_shared<xbox::services::multiplayer::multiplayer_session>(
             STRING_T_FROM_PLATFORM_STRING(xboxLiveContext->User->XboxUserId),
             multiplayerSessionReference->GetCppObj(),
             maxMembersInSession,
             static_cast<xbox::services::multiplayer::multiplayer_session_visibility>(multiplayerSessionVisibility),
             intitiatorIds,
-            sessionCustomConstantsValueString
+            sessionCustomConstantsValueString,
+            sessionCloudComputePackageConstantsValueString
             );
         );
 }
@@ -528,6 +533,16 @@ MultiplayerSession::SetClosed(
 {
     CONVERT_STD_EXCEPTION(
         m_cppObj->set_closed(closed);
+    );
+}
+
+void
+MultiplayerSession::SetAllocateCloudCompute(
+    _In_ bool allocateCloudCompute
+    )
+{
+    CONVERT_STD_EXCEPTION(
+        m_cppObj->set_allocate_cloud_compute(allocateCloudCompute);
     );
 }
 

--- a/Source/Services/Multiplayer/WinRT/MultiplayerSession_WinRT.h
+++ b/Source/Services/Multiplayer/WinRT/MultiplayerSession_WinRT.h
@@ -402,7 +402,8 @@ public:
         _In_ bool reserved,
         _In_ MultiplayerSessionVisibility multiplayerSessionVisibility,
         _In_opt_ Windows::Foundation::Collections::IVectorView<Platform::String^>^ initiatorXboxUserIds,
-        _In_opt_ Platform::String^ sessionCustomConstantsJson
+        _In_opt_ Platform::String^ sessionCustomConstantsJson,
+        _In_opt_ Platform::String^ sessionCloudComputePackageConstantsJson
         );
 #endif
 
@@ -428,7 +429,8 @@ public:
         _In_ uint32 maxMembersInSession,
         _In_ MultiplayerSessionVisibility multiplayerSessionVisibility,
         _In_opt_ Windows::Foundation::Collections::IVectorView<Platform::String^>^ initiatorXboxUserIds,
-        _In_opt_ Platform::String^ sessionCustomConstantsJson
+        _In_opt_ Platform::String^ sessionCustomConstantsJson,
+        _In_opt_ Platform::String^ sessionCloudComputePackageConstantsJson
         );
 
     /// <summary>
@@ -1004,6 +1006,19 @@ public:
         );
 
     /// <summary>
+    /// Sets the session properties/system/allocateCloudCompute field
+    /// </summary>
+    /// <param name="closed">This triggers a Thunderhead allocation attempt by MPSD</param>
+    /// <remarks>
+    /// After calling this method, the caller must use MultiplayerService.WriteSessionAsync to write batched local changes
+    /// to the service.If SetHostDeviceToken is called without calling WriteSessionAsync, it only changes the local session
+    /// object but does not commit it to the service.
+    /// </remarks>
+    void SetAllocateCloudCompute(
+        _In_ bool allocateCloudCompute
+        );
+
+    /// <summary>
     /// Sets a flag that indicates if a match is not successful and needs to be resubmitted, or if the match is successful
     /// and the matchmaking service can release the session.
     /// </summary>
@@ -1267,7 +1282,8 @@ public:
         _In_ uint32 maxMembersInSession,
         _In_ MultiplayerSessionVisibility multiplayerSessionVisibility,
         _In_opt_ Windows::Foundation::Collections::IVectorView<Platform::String^>^ initiatorXboxUserIds,
-        _In_opt_ Platform::String^ sessionCustomConstantsJson
+        _In_opt_ Platform::String^ sessionCustomConstantsJson,
+        _In_opt_ Platform::String^ sessionCloudComputePackageConstantsJson
         );
 
 internal:

--- a/Source/Services/Multiplayer/multiplayer_internal.h
+++ b/Source/Services/Multiplayer/multiplayer_internal.h
@@ -333,6 +333,12 @@ public:
     bool closed() const;
     void set_closed(_In_ bool closed);
 
+    bool write_allocate_cloud_compute() const;
+    void set_write_allocate_cloud_compute(_In_ bool writeAllocateCloudCompute);
+
+    bool allocate_cloud_compute() const;
+    void set_allocate_cloud_compute(_In_ bool allocateCloudCompute);
+
     void set_mutable_role_settings(_In_ const std::unordered_map<string_t, multiplayer_role_type>& roleTypes);
 
     web::json::value create_properties_json();
@@ -374,6 +380,8 @@ private:
     xbox::services::system::xbox_live_mutex m_lock;
     bool m_writeClosed;
     bool m_closed;
+    bool m_writeAllocateCloudCompute;
+    bool m_allocateCloudCompute;
 };
 
 class multiplayer_invite

--- a/Source/Services/Multiplayer/multiplayer_session.cpp
+++ b/Source/Services/Multiplayer/multiplayer_session.cpp
@@ -96,7 +96,8 @@ multiplayer_session::multiplayer_session(
     _In_ uint32_t maxMembersInSession,
     _In_ multiplayer_session_visibility multiplayerSessionVisibility,
     _In_ std::vector<string_t> initiatorXboxUserIds,
-    _In_ web::json::value sessionCustomConstantsJson
+    _In_ web::json::value sessionCustomConstantsJson,
+    _In_ web::json::value sessionCloudComputePackageConstantsJson
     ) :
     m_xboxUserId(std::move(xboxUserId)),
     m_sessionReference(std::move(sessionReference)),
@@ -122,11 +123,19 @@ multiplayer_session::multiplayer_session(
     {
         sessionCustomConstants = std::move(sessionCustomConstantsJson);
     }
+
+    web::json::value sessionCloudComputePackageConstants;
+    if (!sessionCloudComputePackageConstantsJson.is_null())
+    {
+        sessionCloudComputePackageConstants = std::move(sessionCloudComputePackageConstantsJson);
+    }
+
     m_sessionConstants = std::make_shared<multiplayer_session_constants>(
         maxMembersInSession,
         multiplayerSessionVisibility,
         initiatorXboxUserIds,
-        sessionCustomConstants
+        sessionCustomConstants,
+        sessionCloudComputePackageConstants
         );
 
     m_sessionRequest->set_session_constants(m_sessionConstants);
@@ -771,6 +780,15 @@ multiplayer_session::set_closed(
 {
     m_sessionRequest->set_write_closed(true);
     m_sessionRequest->set_closed(closed);
+}
+
+void 
+multiplayer_session::set_allocate_cloud_compute(
+    _In_ bool allocateCloudCompute
+    )
+{
+    m_sessionRequest->set_write_allocate_cloud_compute(true);
+    m_sessionRequest->set_allocate_cloud_compute(allocateCloudCompute);
 }
 
 void

--- a/Source/Services/Multiplayer/multiplayer_session_constants.cpp
+++ b/Source/Services/Multiplayer/multiplayer_session_constants.cpp
@@ -27,6 +27,7 @@ multiplayer_session_constants::multiplayer_session_constants() :
     m_writeMeasurementServerAddresses(false)
 {
     m_sessionCustomConstants = web::json::value::object();
+    m_sessionCloudComputePackageConstants = web::json::value::object();
     m_measurementServerAddressesJson = web::json::value::object();
 }
 
@@ -34,12 +35,14 @@ multiplayer_session_constants::multiplayer_session_constants(
     _In_ uint32_t maxMembersInSession,
     _In_ multiplayer_session_visibility visibility,
     _In_ std::vector<string_t> initiatorXboxIds,
-    _In_ web::json::value sessionCustomConstants
+    _In_ web::json::value sessionCustomConstants,
+    _In_ web::json::value sessionCloudComputePackageConstants
     ) : 
     m_maxMembersInSession(maxMembersInSession),
     m_visibility(visibility),
     m_initiatorXboxUserIds(std::move(initiatorXboxIds)),
     m_sessionCustomConstants(std::move(sessionCustomConstants)),
+    m_sessionCloudComputePackageConstants(std::move(sessionCloudComputePackageConstants)),
     m_shouldSerialize(true),
     m_writeTimeouts(false),
     m_writeArbitrationTimeouts(false),
@@ -124,6 +127,12 @@ const web::json::value&
 multiplayer_session_constants::session_custom_constants_json() const
 {
     return m_sessionCustomConstants;
+}
+
+const web::json::value&
+multiplayer_session_constants::session_cloud_compute_package_constants_json() const
+{
+    return m_sessionCloudComputePackageConstants;
 }
 
 const std::chrono::milliseconds&
@@ -629,6 +638,11 @@ multiplayer_session_constants::_Serialize()
         systemJson[_T("measurementServerAddresses")] = m_measurementServerAddressesJson;
     }
 
+    if (!m_sessionCloudComputePackageConstants.is_null())
+    {
+        systemJson[_T("cloudComputePackage")] = m_sessionCloudComputePackageConstants;
+    }
+
     serializedObject[_T("system")] = systemJson;
 
     if (!m_sessionCustomConstants.is_null())
@@ -652,6 +666,7 @@ multiplayer_session_constants::_Deserialize(
     web::json::value systemCapabilitiesJson = utils::extract_json_field(systemJson, _T("capabilities"), errc, false);
     web::json::value systemMetricsJson = utils::extract_json_field(systemJson, _T("metrics"), errc, false);
     web::json::value systemArbitrationTimeoutsJson = utils::extract_json_field(systemJson, _T("arbitration"), errc, false);
+    returnResult.m_sessionCloudComputePackageConstants = utils::extract_json_field(systemJson, _T("cloudComputePackage"), errc, false);
 
     returnResult.m_maxMembersInSession = utils::extract_json_int(systemJson, _T("maxMembersCount"), errc);
 

--- a/Source/Services/Multiplayer/multiplayer_session_properties.cpp
+++ b/Source/Services/Multiplayer/multiplayer_session_properties.cpp
@@ -35,6 +35,7 @@ multiplayer_session_properties& multiplayer_session_properties::_Deep_copy(
     m_serverConnectionString = other.m_serverConnectionString;
     m_serverConnectionStringCandidates = other.m_serverConnectionStringCandidates;
     m_closed = other.m_closed;
+    m_allocateCloudCompute = other.m_allocateCloudCompute;
 
     // We will set this from the session deep_copy.
     m_sessionRequest = std::make_shared<multiplayer_session_request>();
@@ -159,6 +160,13 @@ multiplayer_session_properties::closed() const
 {
     std::lock_guard<std::mutex> lock(m_lock);
     return m_closed;
+}
+
+bool 
+multiplayer_session_properties::allocate_cloud_compute() const
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+    return m_allocateCloudCompute;
 }
 
 void 
@@ -305,6 +313,8 @@ multiplayer_session_properties::_Deserialize(
     }
 
     returnResult.m_closed = utils::extract_json_bool(systemJson, _T("closed"), errc);
+
+    returnResult.m_allocateCloudCompute = utils::extract_json_bool(systemJson, _T("allocateCloudCompute"), errc);
 
     returnResult.m_matchmakingTargetSessionConstants = utils::extract_json_field(systemMatchmakingJson, _T("targetSessionConstants"), errc, false);
     returnResult.m_customPropertiesJson = utils::extract_json_field(json, _T("custom"), errc, false);

--- a/Source/Services/Multiplayer/multiplayer_session_request.cpp
+++ b/Source/Services/Multiplayer/multiplayer_session_request.cpp
@@ -51,6 +51,8 @@ void multiplayer_session_request::deep_copy_from(
     m_memberRequestIndex = other.m_memberRequestIndex;
     m_writeClosed = other.m_writeClosed;
     m_closed = other.m_closed;
+    m_writeAllocateCloudCompute = other.m_writeAllocateCloudCompute;
+    m_allocateCloudCompute = other.m_allocateCloudCompute;
 }
 
 multiplayer_session_request::multiplayer_session_request() :
@@ -68,7 +70,9 @@ multiplayer_session_request::multiplayer_session_request() :
     m_memberRequestIndex(0),
     m_bLeaveSession(false),
     m_writeClosed(false),
-    m_closed(false)
+    m_closed(false),
+    m_writeAllocateCloudCompute(false),
+    m_allocateCloudCompute(false)
 {
     m_sessionConstants = std::make_shared<multiplayer_session_constants>();
     m_sessionPropertiesCustomProperties = web::json::value();
@@ -94,7 +98,9 @@ multiplayer_session_request::multiplayer_session_request(
     m_memberRequestIndex(0),
     m_bLeaveSession(false),
     m_writeClosed(false),
-    m_closed(false)
+    m_closed(false),
+    m_writeAllocateCloudCompute(false),
+    m_allocateCloudCompute(false)
 {
 }
 
@@ -486,6 +492,34 @@ multiplayer_session_request::set_closed(
     m_closed = closed;
 }
 
+bool 
+multiplayer_session_request::write_allocate_cloud_compute() const
+{
+    return m_writeAllocateCloudCompute;
+}
+
+void 
+multiplayer_session_request::set_write_allocate_cloud_compute(
+    _In_ bool writeAllocateCloudCompute
+    )
+{
+    m_writeAllocateCloudCompute = writeAllocateCloudCompute;
+}
+
+bool 
+multiplayer_session_request::allocate_cloud_compute() const
+{
+    return m_allocateCloudCompute;
+}
+
+void 
+multiplayer_session_request::set_allocate_cloud_compute(
+    _In_ bool allocateCloudCompute
+    )
+{
+    m_allocateCloudCompute = allocateCloudCompute;
+}
+
 void
 multiplayer_session_request::set_mutable_role_settings(
     _In_ const std::unordered_map<string_t, multiplayer_role_type>& roleTypes
@@ -528,6 +562,11 @@ multiplayer_session_request::create_properties_json()
     if (m_writeClosed)
     {
         jsonPropertiesSystem[_T("closed")] = web::json::value(m_closed);
+    }
+
+    if (m_writeAllocateCloudCompute)
+    {
+        jsonPropertiesSystem[_T("allocateCloudCompute")] = web::json::value(m_allocateCloudCompute);
     }
 
     if (m_writeMatchmakingClientResult || m_writeMatchmakingSessionConstants || m_writeMatchmakingServerConnectionPath)


### PR DESCRIPTION
Changes to support a new method of MPSD Thunderhead allocation (the same
method that PartyChat is now using). To support using the new allocation
method, I needed to make some changes to how we create and interact with
the game session doc.

We use the XSAPI MultiplayerSession^ on our game clients to create and
interact with game sessions. However, we now needed to be able to read
and write a few new things to the session doc that weren’t supported out
of the box.

1. These values must be set in the session doc at creation:

/constants/system/cloudComputePackage/titleId
: “your cloud title ID as a string”
/constants/system/cloudComputePackage/gsiSet
: “UUID of your cloud compute package”

I added an additional optional parameter to the MultiplayerSession^
constructor called systemConstants, which allows us to pass in json that
gets put into the “/constants/system/” section when creating a new game
session. (I followed the pattern of the existing optional parameter on
the MultiplayerSession^ constructor customConstants, which is json that
is written to “/constants/custom/”). Note that we also need to set these
values on our matchmaking sessions, but the existing
MultiplayerSession::SetMatchmakingTargetSessionConstantsJson() allowed
us to write them into session without any need for XSAPI changes.

2. Then when we want to request an allocation from the client, we need
to write a flag into the session doc

/properties/system/allocateCloudCompute
: Boolean

I added a property to MultiplayerSession^ called AllocateCloudCompute,
following the pattern of the existing Closed property, so that the
client could easily set this to true to request an allocation, and later
detect if MPSD set it to false again (which is how it indicates a failed
allocation).