### PR TITLE
Adding XboxLiveCreatorsTitle bool in xboxservcies.config

### DIFF
--- a/Include/xsapi/types.h
+++ b/Include/xsapi/types.h
@@ -141,23 +141,6 @@ typedef void* user_creation_context;
 typedef  Windows::Xbox::System::User^ xbox_live_user_t;
 #endif
 
-
-#if UWP_API
-    extern bool g_is_xbox_live_creators_sdk;
-    #if XSAPI_CPP
-        // The same C++ binary is shared to titles with and without XBOX_LIVE_CREATORS_SDK defined
-        // XSAPI uses an external bool that will be defined at the time of when the title includes this header
-        #if !defined(XSAPI_BUILD)
-            #if defined(XBOX_LIVE_CREATORS_SDK)
-                bool g_is_xbox_live_creators_sdk = true;
-            #else
-                bool g_is_xbox_live_creators_sdk = false;
-            #endif
-        #endif
-    #endif
-#endif
-
-
 #if defined(XSAPI_CPPWINRT)
 #if TV_API
 inline Windows::Xbox::System::User^ convert_user_to_cppcx(_In_ const winrt::Windows::Xbox::System::User& user)

--- a/Source/Services/Misc/UWP/title_callable_ui.cpp
+++ b/Source/Services/Misc/UWP/title_callable_ui.cpp
@@ -493,7 +493,7 @@ title_callable_ui::_Get_gaming_privilege_scope_policy(
         localConfig->environment_prefix(),
         localConfig->environment(),
         localConfig->use_first_party_token(),
-        g_is_xbox_live_creators_sdk
+        localConfig->is_creators_title()
         );
 
     scope = ref new Platform::String(authConfig.rps_ticket_service().c_str());

--- a/Source/Shared/local_config.cpp
+++ b/Source/Shared/local_config.cpp
@@ -168,6 +168,12 @@ bool local_config::use_first_party_token()
     return get_bool_from_config(_T("FirstParty"), false, false);
 }
 
+bool local_config::is_creators_title()
+{
+    return get_bool_from_config(_T("XboxLiveCreatorsTitle"), false, false);
+}
+
+
 #if XSAPI_I
 string_t local_config::apns_environment()
 {

--- a/Source/Shared/local_config.h
+++ b/Source/Shared/local_config.h
@@ -40,6 +40,7 @@ public:
     virtual string_t sandbox();
     virtual string_t client_secret();
     virtual bool use_first_party_token();
+    virtual bool is_creators_title();
 
     virtual string_t get_value_from_local_storage(_In_ const string_t& name);
     virtual xbox_live_result<void> write_value_to_local_storage(_In_ const string_t& name, _In_ const string_t& value);

--- a/Source/System/auth_config.cpp
+++ b/Source/System/auth_config.cpp
@@ -42,7 +42,7 @@ auth_config::auth_config(
     _In_ string_t environmentPrefix,
     _In_ string_t environment,
     _In_ bool useCompactTicket,
-    _In_ bool isCreatorsSDK) :
+    _In_ bool isCreatorsTitle) :
     m_useCompactTicket(useCompactTicket),
     m_sandbox(std::move(sandbox)),
     m_detailError(0),
@@ -58,7 +58,7 @@ auth_config::auth_config(
     m_serviceTokenEndpoint = get_endpoint_path(_T("service.auth"), environmentPrefix, environment);
     m_xTokenEndpoint = get_endpoint_path(_T("xsts.auth"), environmentPrefix, environment);
     m_userTokenSiteName = get_endpoint_path(_T("user.auth"), _T(""), environment, false); 
-    m_rpsTicketService = isCreatorsSDK ? _T("xbl.signin xbl.friends") : (useCompactTicket ? m_userTokenSiteName : _T("xboxlive.signin"));
+    m_rpsTicketService = isCreatorsTitle ? _T("xbl.signin xbl.friends") : (useCompactTicket ? m_userTokenSiteName : _T("xboxlive.signin"));
     m_xtokenComposition = { token_identity_type::u_token, token_identity_type::d_token, token_identity_type::t_token };
 }
 

--- a/Source/System/auth_config.h
+++ b/Source/System/auth_config.h
@@ -30,7 +30,7 @@ public:
         _In_ string_t environmentPrefix,
         _In_ string_t environment,
         _In_ bool useCompactTicket,
-        _In_ bool isCreatorsSDK
+        _In_ bool isCreatorsTitle
         );
 
     const string_t& xbox_live_endpoint() const;

--- a/Source/System/user_impl.cpp
+++ b/Source/System/user_impl.cpp
@@ -12,10 +12,6 @@
 #endif
 #endif
 
-#if UNIT_TEST_SERVICES
-bool g_is_xbox_live_creators_sdk = false;
-#endif
-
 using namespace std;
 using namespace pplx;
 
@@ -55,7 +51,7 @@ user_impl::user_impl(
         m_localConfig->environment_prefix(),
         m_localConfig->environment(),
         m_localConfig->use_first_party_token(),
-        g_is_xbox_live_creators_sdk
+        m_localConfig->is_creators_title()
         );
 #endif
 }

--- a/Source/System/user_impl.h
+++ b/Source/System/user_impl.h
@@ -11,10 +11,6 @@
 #include "auth/auth_manager.h"
 #endif
 
-#if UNIT_TEST_SERVICES
-extern bool g_is_xbox_live_creators_sdk;
-#endif
-
 NAMESPACE_MICROSOFT_XBOX_SERVICES_SYSTEM_CPP_BEGIN
 
 class user_impl : public std::enable_shared_from_this<user_impl>

--- a/Tests/CreatorsCppTestApp/UWP/Cpp/Package.appxmanifest
+++ b/Tests/CreatorsCppTestApp/UWP/Cpp/Package.appxmanifest
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name='38133JasonSandlin.Social-XboxLiveSDKSample' Version="1.1.0.0" Publisher='CN=21A176D6-65FC-40A6-A44A-7DC730DA0070' />
+  <Identity Name='41336MicrosoftATG.XBLCreatorsSampleSocial' Version="1.1.0.0" Publisher='CN=A4954634-DF4B-47C7-AB70-D3215D246AF1' />
   <mp:PhoneIdentity PhoneProductId="997b70fc-d78e-48b7-ac75-4e3ed52d945a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Xbox LIVE SDK Sample - Social</DisplayName>
-    <PublisherDisplayName>Microsoft</PublisherDisplayName>
+    <PublisherDisplayName>Placeholder_7406</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>

--- a/Tests/CreatorsCppTestApp/UWP/Cpp/xboxservices.config
+++ b/Tests/CreatorsCppTestApp/UWP/Cpp/xboxservices.config
@@ -1,4 +1,5 @@
 {
-    "TitleId" : 929134689,
-    "PrimaryServiceConfigId" : "15350100-1645-4a71-a180-2d5637617861"
+    "TitleId" : 1934598432,
+    "PrimaryServiceConfigId" : "00000000-0000-0000-0000-0000734fa120",
+    "XboxLiveCreatorsTitle" : true    
 }


### PR DESCRIPTION
Previously was using static bool that title defined by including xsapi headers and that caused trouble if title code included xsapi headers in multiple cpp files, so moving to this more sound method