### PR TITLE
Fixing issue with browse_catalog_bundles fails with HTTP 400

### DIFF
--- a/Source/Services/Marketplace/catalog_service.cpp
+++ b/Source/Services/Marketplace/catalog_service.cpp
@@ -389,12 +389,10 @@ string_t catalog_service::marketplace_browse_catalog_subpath(
         param << _T("relationship=");
         param << web::uri::encode_uri(relationship);
         params.push_back(param.str());
-
-        // We don't add the 'orderBy' with a bundle relationship browse
     }
-    else
+    
+    if (!orderBy.empty())
     {
-        // If this is not a bundle relationship call, add the orderBy filter
         stringstream_t param;
         param << _T("orderBy=");
         param << web::uri::encode_uri(orderBy);
@@ -486,7 +484,7 @@ catalog_service::browse_catalog_bundles_helper(
         _Convert_media_item_type_to_string(parentMediaType),
         _T("DGame.DDurable.DConsumable.DApp"),  // get all related product types in the bundle
         convert_bundle_relationship_type_to_string(relationship),
-        string_t(),                                 // No need to sort on a bundle search
+        convert_sort_order_to_string( catalog_sort_order::release_date ).payload(),  // bundles_with_product requires a sorting field
         skipItems,
         maxItems
         );


### PR DESCRIPTION
Fixing issue with browse_catalog_bundles fails with HTTP 400 when using bundle_relationship_type::bundles_with_product.

The catalog service now requires you to specify a sort order if asking for which bundles a product is part of.