### PR TITLE
Bug fix to do write inside stats manager even if read fails

### DIFF
--- a/Source/Services/Stats/Manager/stats_manager_impl.cpp
+++ b/Source/Services/Stats/Manager/stats_manager_impl.cpp
@@ -293,8 +293,9 @@ stats_manager_impl::flush_to_service(
             if (!svdResult.err())
             {
                 userIter->second.statValueDocument.merge_stat_value_documents(svdResult.payload());
-                pThis->update_stats_value_document(userIter->second);
             }
+
+            pThis->update_stats_value_document(userIter->second);
         });
     }
     else


### PR DESCRIPTION
Bug 11973099: [XSAPI] Port stats manager fix to C++ stats manager