### PR TITLE
Fixing an issue where CompareMultiplayerSessions would miss changes related to Matchmaking

### DIFF
--- a/Include/xsapi/multiplayer.h
+++ b/Include/xsapi/multiplayer.h
@@ -3524,6 +3524,16 @@ public:
     /// </summary>
     static std::error_code _Populate_members_with_members_list(_In_ std::vector<std::shared_ptr<multiplayer_session_member>> members);
 
+    static bool _Do_session_references_match(
+        _In_ xbox::services::multiplayer::multiplayer_session_reference sessionRef1,
+        _In_ xbox::services::multiplayer::multiplayer_session_reference sessionRef2
+        )
+    {
+        return  utils::str_icmp(sessionRef1.service_configuration_id(), sessionRef2.service_configuration_id()) == 0 &&
+            utils::str_icmp(sessionRef1.session_template_name(), sessionRef2.session_template_name()) == 0 &&
+            utils::str_icmp(sessionRef1.session_name(), sessionRef2.session_name()) == 0;
+    }
+
     /// <summary>
     /// Internal function
     /// </summary>

--- a/Source/Services/Multiplayer/multiplayer_session.cpp
+++ b/Source/Services/Multiplayer/multiplayer_session.cpp
@@ -1429,8 +1429,14 @@ multiplayer_session::compare_multiplayer_sessions(
         currentType |= multiplayer_session_change_types::initialization_state_change;
     }
 
-    if ((currentSession->matchmaking_server().is_null() != oldSession->matchmaking_server().is_null()) ||
-        (!currentSession->matchmaking_server().is_null() && currentSession->matchmaking_server().status() != oldSession->matchmaking_server().status())
+    auto currentMatchmakingServer = currentSession->matchmaking_server();
+    auto oldMatchmakingServer = oldSession->matchmaking_server();
+    if ((currentMatchmakingServer.is_null() != oldMatchmakingServer.is_null()) ||
+        (!currentMatchmakingServer.is_null() && currentMatchmakingServer.status() != oldMatchmakingServer.status()) ||
+        (!currentMatchmakingServer.is_null() && 
+            !currentMatchmakingServer.target_session_ref().is_null() &&
+            !oldMatchmakingServer.target_session_ref().is_null() &&
+            !_Do_session_references_match(currentMatchmakingServer.target_session_ref(), oldMatchmakingServer.target_session_ref()))
         )
     {
         currentType |= multiplayer_session_change_types::matchmaking_status_change;

--- a/Tests/UnitTests/Tests/Services/MultiplayerTests.cpp
+++ b/Tests/UnitTests/Tests/Services/MultiplayerTests.cpp
@@ -2853,6 +2853,27 @@ public:
         VERIFY_IS_FALSE(static_cast<MultiplayerSessionChangeTypes>(static_cast<uint32>(MultiplayerSessionChangeTypes::CustomPropertyChange) & changeType) == MultiplayerSessionChangeTypes::CustomPropertyChange);
         VERIFY_IS_FALSE(static_cast<MultiplayerSessionChangeTypes>(static_cast<uint32>(MultiplayerSessionChangeTypes::MemberStatusChange) & changeType) == MultiplayerSessionChangeTypes::MemberStatusChange);
         VERIFY_IS_FALSE(static_cast<MultiplayerSessionChangeTypes>(static_cast<uint32>(MultiplayerSessionChangeTypes::MemberCustomPropertyChange) & changeType) == MultiplayerSessionChangeTypes::MemberCustomPropertyChange);
+
+        // Test MatchmakingStatusChange for different target session refs.
+        currentSession = ref new MultiplayerSession(
+            std::make_shared<multiplayer_session>(
+                sessionResult.payload()
+                )
+            );
+
+        const string_t responseForComparingSessions = testResponseJsonFromFile[L"MultiplayerResponseForComparingSessions"].serialize();
+        auto compareSessionResult = multiplayer_session::_Deserialize(
+            web::json::value::parse(responseForComparingSessions)
+            );
+        VERIFY_IS_TRUE(!compareSessionResult.err());
+        auto compareSession = ref new MultiplayerSession(
+            std::make_shared<multiplayer_session>(
+                compareSessionResult.payload()
+                )
+            );
+
+        changeType = static_cast<uint32>(MultiplayerSession::CompareMultiplayerSessions(currentSession, compareSession));
+        VERIFY_IS_TRUE(static_cast<MultiplayerSessionChangeTypes>(static_cast<uint32>(MultiplayerSessionChangeTypes::MatchmakingStatusChange) & changeType) == MultiplayerSessionChangeTypes::MatchmakingStatusChange);
     }
 
     DEFINE_TEST_CASE(TestRTAMultiplayer)

--- a/Tests/UnitTests/Tests/Services/TestResponses/Multiplayer.json
+++ b/Tests/UnitTests/Tests/Services/TestResponses/Multiplayer.json
@@ -296,6 +296,287 @@
             }
         }
     },
+	"MultiplayerResponseForComparingSessions" : {
+        "branch": "b65ae271-a117-4359-b963-27ff55d3ab92",
+        "changeNumber": 1,
+        "contractVersion": 105,
+        "correlationId": "06365b64-3067-8039-ecee-3608af3d02fc",
+        "startTime": "2013-02-01T00:00:00Z",
+        "nextTimer": "2013-02-01T00:00:00Z",
+        "initializing": {
+            "stage": "Measuring",
+            "stageStartTime": "2013-02-01T00:00:00Z",
+            "episode": 0
+        },
+        "hostCandidates": [
+            "ab90a362",
+            "99582e67"
+        ],
+        "membersInfo": {
+            "first": 0,
+            "next": 1,
+            "count": 2,
+            "accepted": 1,
+            "active": 1
+        },
+        "roleTypes": {
+            "lfg": {
+                "ownerManaged": true,
+                "mutableRoleSettings":["max", "target"],
+                "roles": {
+                    "friend":{
+                        "count": 2,
+                        "target": 3,
+                        "max": 5,
+                        "memberXuids" : ["1234", "5678"]
+                    },
+                    "other":{
+                        "count": 3,
+                        "target": 3,
+                        "max": 5,
+                        "memberXuids" : ["1234", "5678"]
+                    }
+                }
+            }
+        },
+        "constants": {
+            "system": {
+                "capabilities": {
+                    "clientMatchmaking": true,
+                    "connectivity": true,
+                    "suppressPresenceActivityCheck": true,
+                    "gameplay": true,
+                    "large": false,
+                    "userAuthorizationStyle": true,
+                    "crossplay": true,
+                    "searchable": true,
+                    "connectionRequiredForActiveMembers": true
+                },
+                "version": 1,
+                "maxMembersCount": 100,
+                "visibility": "Open",
+                "initiators": [
+                    "3456"
+                ],
+                "inviteProtocol": "party",
+                "reservedRemovalTimeout": 30000,
+                "inactiveRemovalTimeout": 7200000,
+                "readyRemovalTimeout": 180000,
+                "sessionEmptyTimeout": 0,
+                "metrics": {
+                    "latency": true,
+                    "bandwidthDown": true,
+                    "bandwidthUp": true,
+                    "custom": true
+                },
+                "memberInitialization": {
+                    "joinTimeout": 4000,
+                    "measurementTimeout": 5000,
+                    "evaluationTimeout": 5000,
+                    "externalEvaluation": false,
+                    "membersNeededToStart": 2
+                },
+                "peerToPeerRequirements": {
+                    "latencyMaximum": 250,
+                    "bandwidthMinimum": 10000
+                },
+                "peerToHostRequirements": {
+                    "latencyMaximum": 250,
+                    "bandwidthDownMinimum": 100000,
+                    "bandwidthUpMinimum": 1000,
+                    "hostSelectionMetric": "bandwidthUp"
+                },
+                "measurementServerAddresses": {
+                    "east.azure.com": {
+                        "secureDeviceAddress": "r5Y="
+                    },
+                    "west.azure.com": {
+                        "secureDeviceAddress": "rwY="
+                    }
+                },
+                "cloudComputePackage": {
+                    "crossSandbox": true,
+                    "titleId": "4567",
+                    "gsiSet": "128ce92a-45d0-4319-8a7e-bd8e940114ec"
+                }
+            },
+            "custom": {}
+        },
+        "properties": {
+            "system": {
+                "closed": true,
+                "locked": true,
+                "allocateCloudCompute": true,
+                "keywords": [
+                    "hello"
+                ],
+                "turn": [
+                    0
+                ],
+                "owners": [0],
+                "host": "99e4c701",
+                "initializationSucceeded": true,
+                "joinRestriction": "None",
+                "readRestriction": "None",
+                "serverConnectionStringCandidates": [
+                    "west.azure.com",
+                    "east.azure.com"
+                ],
+                "matchmaking": {
+                    "clientResult": {
+                        "status": "Searching",
+                        "statusDetails": "Description",
+                        "typicalWait": 30,
+                        "targetSessionRef": {
+                            "scid": "1ECFDB89-36EB-4E59-8901-11F7393689AE",
+                            "templateName": "capture-the-flag",
+                            "name": "2D58F65F-0E3C-4F1F-8277-2BC9873FDB23"
+                        }
+                    },
+                    "targetSessionConstants": {},
+                    "serverConnectionString": "west.azure.com"
+                },
+                "matchmakingResubmit": true
+            },
+            "custom": {}
+        },
+        "servers": {
+            "matchmaking": {
+                "properties": {
+                    "system": {
+                        "status": "searching",
+                        "statusDetails": "test",
+                        "typicalWait": 10000,
+                        "targetSessionRef": {
+                            "scid": "1ECFDB89-36EB-4E59-8901-11F7393689AE",
+                            "templateName": "capture-the-flag",
+                            "name": "12345678-0E3C-4F1F-8277-2BC9873FDB23"
+                        }
+                    }
+                }
+            }
+        },
+        "members": {
+            "0": {
+                "roles": {
+                    "lfg": "friend",
+                    "admin": "super"
+                },
+                "constants": {
+                    "system": {
+                        "index": 0,
+                        "xuid": "TestXboxUserId",
+                        "initialize": true,
+                        "matchmakingResult": {
+                            "serverMeasurements": {
+                                "east.azure.com": {
+                                    "latency": 233
+                                }
+                            }
+                        }
+                    },
+                    "custom": "Hello"
+                },
+                "properties": {
+                    "system": {
+                        "subscription": {
+                            "changeTypes": [
+                                "everything",
+                                "host"
+                            ]
+                        },
+                        "ready": true,
+                        "active": false,
+                        "secureDeviceAddress": "ryY=",
+                        "initializationGroup": [
+                            5
+                        ],
+                        "measurements": {
+                            "e6Kv5zY=": {
+                                "latency": 5953,
+                                "bandwidthDown": 19342,
+                                "bandwidthUp": 944,
+                                "custom": {}
+                            }
+                        },
+                        "serverMeasurements": {
+                            "east.azure.com": {
+                                "latency": 233
+                            }
+                        }
+                    },
+                    "custom": {}
+                },
+                "gamertag": "stacy",
+                "deviceToken": "9f4032ba7",
+                "nat": "Strict",
+                "reserved": true,
+                "activeTitleId": "8397267",
+                "joinTime": "2013-02-01T00:00:00Z",
+                "turn": true,
+                "initializationFailure": "Latency",
+                "initializationEpisode": 0,
+                "next": 1
+            },
+            "1": {
+                "constants": {
+                    "system": {
+                        "index": 1,
+                        "xuid": "1234",
+                        "initialize": true,
+                        "matchmakingResult": {
+                            "serverMeasurements": {
+                                "east.azure.com": {
+                                    "latency": 233
+                                }
+                            }
+                        }
+                    },
+                    "custom": {}
+                },
+                "properties": {
+                    "system": {
+                        "subscription": {
+                            "changeTypes": [
+                                "everything",
+                                "host"
+                            ]
+                        },
+                        "ready": true,
+                        "active": false,
+                        "secureDeviceAddress": "ryY=",
+                        "initializationGroup": [
+                            5
+                        ],
+                        "measurements": {
+                            "e6Kv5zY=": {
+                                "latency": 5953,
+                                "bandwidthDown": 19342,
+                                "bandwidthUp": 944,
+                                "custom": {}
+                            }
+                        },
+                        "serverMeasurements": {
+                            "east.azure.com": {
+                                "latency": 233
+                            }
+                        }
+                    },
+                    "custom": {}
+                },
+                "gamertag": "stacy",
+                "deviceToken": "9f4032ba7",
+                "nat": "Strict",
+                "reserved": true,
+                "activeTitleId": "8397267",
+                "joinTime": "2013-02-01T00:00:00Z",
+                "turn": true,
+                "initializationFailure": "Latency",
+                "initializationEpisode": 0,
+                "next": 4
+            }
+        }
+    },
     "rtaSessionUpdateJson" : {
         "ncid": "508e6b30-e694-42ad-a396-5ff48612463f",
         "shoulderTaps": [


### PR DESCRIPTION
CompareMultiplayerSessions wasn't comparing the sessions' MatchmakingServer's Target Sessions. This would result in no MultiplayerSessionChangeTypes when compared even though the Target Sessions had  changed.