### PR TITLE
Fix Multiplayer Manager invite dialog handling by catching all exceptions

### DIFF
--- a/Source/Services/Multiplayer/Manager/multiplayer_client_manager.cpp
+++ b/Source/Services/Multiplayer/Manager/multiplayer_client_manager.cpp
@@ -501,7 +501,7 @@ multiplayer_client_manager::invite_friends(
                 t.get();
                 pThis->add_multiplayer_event(multiplayer_event_type::invite_sent, multiplayer_session_type::lobby_session);
             }
-            catch (Platform::Exception^ ex)
+            catch (...)
             {
                 xbox_live_error_code err = utils::convert_exception_to_xbox_live_error_code();
                 pThis->add_multiplayer_event(multiplayer_event_type::invite_sent, multiplayer_session_type::lobby_session, err, "Failed sending invites.");


### PR DESCRIPTION
I found out that invite dialog handling and event providing can completely fail if the dialog is dismissed without sending any invites. This behavior was possible because the code was only catching WinRT exceptions. If you dismiss the dialog without doing anything, it will cancel the invite task causing Concurrency::task_canceled to get thrown. This is an exception derived from std::exception but normal C++ exceptions weren't handled at all. 

As a result, invite_sent events were never dispatched and it wasn't possible to open the dialog anymore.  