### PR TITLE
Increase XBOX_USER_ID_CHAR_SIZE from 17 to 21.

### DIFF
--- a/Include/xsapi/social_manager.h
+++ b/Include/xsapi/social_manager.h
@@ -38,7 +38,7 @@ enum class change_list_enum;
 
 static const uint32_t GAMERSCORE_CHAR_SIZE = 16;
 static const uint32_t GAMERTAG_CHAR_SIZE = 16;
-static const uint32_t XBOX_USER_ID_CHAR_SIZE = 17;
+static const uint32_t XBOX_USER_ID_CHAR_SIZE = 21;
 static const uint32_t DISPLAY_NAME_CHAR_SIZE = 30;
 static const uint32_t REAL_NAME_CHAR_SIZE = 255;
 static const uint32_t DISPLAY_PIC_URL_RAW_CHAR_SIZE = 225;


### PR DESCRIPTION
The maximum decimal value of a 64-bit unsigned integer is 18446744073709551615, which is 20 characters. +1 for a null terminator. The current value of 17 is too small, and currently causes issues when multiple guests are signed in as the generated XUID is 18 digits.