### PR TITLE
Fixing issue with catalog bundle API calls.  

### DIFF
--- a/Source/Services/Marketplace/catalog_service.cpp
+++ b/Source/Services/Marketplace/catalog_service.cpp
@@ -539,7 +539,7 @@ catalog_service::browse_catalog_bundles_helper(
         }
         
         return utils::generate_xbox_live_result<browse_catalog_result>(
-            browse_catalog_result::_Deserialize(response->response_body_json()),
+            catalogResult,
             response
             );
     });


### PR DESCRIPTION
Code was passing back a new uninitialized payload rather than the object that was initialized in the code above as the non-bundle version of the APIs do.  Was causing an exception in the In Game Store sample as the has_next() API would return true when there was no get next call to be made.