### PR TITLE
Added a missing nullptr check in multiplayer client manager

### DIFF
--- a/Source/Services/Multiplayer/Manager/multiplayer_client_manager.cpp
+++ b/Source/Services/Multiplayer/Manager/multiplayer_client_manager.cpp
@@ -638,7 +638,7 @@ multiplayer_client_manager::is_request_in_progress()
 bool
 multiplayer_client_manager::is_update_avaialable()
 {
-    if (m_latestPendingRead == nullptr)
+    if (m_latestPendingRead == nullptr || m_lastPendingRead == nullptr)
     {
         return false;
     }


### PR DESCRIPTION
We encountered a crash due to this null pointer once while debugging other stuff. More in depth reason is unknown but at least this should help prevent immediate crashes.