### PR TITLE
Perf fix in social manager, http response regression fix

### DIFF
--- a/Source/Services/Social/Manager/social_graph.cpp
+++ b/Source/Services/Social/Manager/social_graph.cpp
@@ -190,7 +190,6 @@ void social_graph::initialize(xbox_live_callback<xbox_live_result<void>> callbac
 
     auto context = xsapi_allocate_shared<do_event_work_context>();
     context->pThis = thisWeakPtr;
-    context->hasRemainingEvent = true;
     context->outerAsyncBlock = eventWorkAsync;
     eventWorkAsync->queue = m_backgroundAsyncQueue;
     eventWorkAsync->context = utils::store_shared_ptr(context);
@@ -341,14 +340,17 @@ social_graph::schedule_event_work(do_event_work_context* context)
             auto pThis = context->pThis.lock();
             if (pThis)
             {
-                context->hasRemainingEvent = pThis->do_event_work();
+                bool hasRemainingEvent = false;
+                do
+                {
+                    hasRemainingEvent = pThis->do_event_work();
+                } while (hasRemainingEvent);
             }
             CompleteAsync(data->async, S_OK, 0);
-            return E_PENDING;
         }
         return S_OK;
     });
-    ScheduleAsync(nestedAsync, context->hasRemainingEvent ? 0 : 30);
+    ScheduleAsync(nestedAsync, 30);
 }
 
 bool
@@ -1347,7 +1349,7 @@ social_graph::do_work(
         socialEvents.reserve(socialEvents.size() + m_socialEventQueue.social_event_list().size());
         for (auto& evt : m_socialEventQueue.social_event_list())
         {
-            socialEvents.push_back(evt);
+            socialEvents.push_back(evt);    
         }
         m_socialEventQueue.clear();
         m_perfTester.stop_timer("do_work: social event push_back");

--- a/Source/Services/Social/Manager/social_graph.cpp
+++ b/Source/Services/Social/Manager/social_graph.cpp
@@ -1349,7 +1349,7 @@ social_graph::do_work(
         socialEvents.reserve(socialEvents.size() + m_socialEventQueue.social_event_list().size());
         for (auto& evt : m_socialEventQueue.social_event_list())
         {
-            socialEvents.push_back(evt);    
+            socialEvents.push_back(evt);
         }
         m_socialEventQueue.clear();
         m_perfTester.stop_timer("do_work: social event push_back");

--- a/Source/Services/Social/Manager/social_manager_internal.h
+++ b/Source/Services/Social/Manager/social_manager_internal.h
@@ -480,7 +480,6 @@ protected:
     {
         std::weak_ptr<social_graph> pThis;
         AsyncBlock* outerAsyncBlock;
-        bool hasRemainingEvent;
     };
 
     void schedule_event_work(do_event_work_context* context);

--- a/Source/Shared/http_call_response.cpp
+++ b/Source/Shared/http_call_response.cpp
@@ -135,8 +135,9 @@ http_call_response_internal::http_call_response_internal(
             if (httpCallData->httpCallResponseBodyType == http_call_response_body_type::json_body)
             {
                 web::json::value responseBodyJson;
-                responseBodyJson = web::json::value::parse(utils::string_t_from_internal_string(responseBody), m_errorCode);
-                if (!m_errorCode)
+                std::error_code errCode;
+                responseBodyJson = web::json::value::parse(utils::string_t_from_internal_string(responseBody), errCode);
+                if (!errCode)
                 {
                     set_response_body(responseBodyJson);
                 }

--- a/Source/Shared/utils.cpp
+++ b/Source/Shared/utils.cpp
@@ -100,7 +100,7 @@ void xsapi_singleton::init()
 #endif
 #endif
 
-#if UNIT_TEST_SERVICES
+#if _DEBUG && UNIT_TEST_SERVICES
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 
@@ -117,7 +117,7 @@ xsapi_singleton::~xsapi_singleton()
 
     if (m_callbackContextPtrs.size() > 0)
     {
-#ifdef UNIT_TEST_SERVICES
+#if _DEBUG && UNIT_TEST_SERVICES
         assert(false && "Context remaining in context store!");
 #endif
         m_callbackContextPtrs.clear();

--- a/Source/System/user_impl.cpp
+++ b/Source/System/user_impl.cpp
@@ -38,7 +38,7 @@ user_impl::user_impl(
     UNREFERENCED_PARAMETER(initConfig);
     m_localConfig = xbox_system_factory::get_factory()->create_local_config();
 
-    m_authConfig = std::make_shared<auth_config>(
+    m_authConfig = xsapi_allocate_shared<auth_config>(
         m_localConfig->sandbox(),
         m_localConfig->environment_prefix(),
         m_localConfig->environment(),

--- a/Tests/UnitTests/Support/TAEF/UnitTestBase_winrt.cpp
+++ b/Tests/UnitTests/Support/TAEF/UnitTestBase_winrt.cpp
@@ -36,7 +36,6 @@ XboxLiveUser^ SignInUserWithMocks_WinRT(const string_t& id)
 Microsoft::Xbox::Services::XboxLiveContext^ GetMockXboxLiveContext_WinRT(const string_t& id)
 {
     auto user = SignInUserWithMocks_WinRT(id);
-    xbox::services::user_context userContext(user);
     Microsoft::Xbox::Services::XboxLiveContext^ xboxLiveContext = ref new Microsoft::Xbox::Services::XboxLiveContext(user);
     return xboxLiveContext;
 }
@@ -44,7 +43,6 @@ Microsoft::Xbox::Services::XboxLiveContext^ GetMockXboxLiveContext_WinRT(const s
 std::shared_ptr<xbox::services::xbox_live_context> GetMockXboxLiveContext_Cpp(const string_t& id)
 {
     auto user = SignInUserWithMocks_WinRT(id);
-    xbox::services::user_context userContext(user);
     Microsoft::Xbox::Services::XboxLiveContext^ xboxLiveContext = ref new Microsoft::Xbox::Services::XboxLiveContext(user);
     return xboxLiveContext->GetCppObj();
 }


### PR DESCRIPTION
* Perf improvement in social manager - process multiple events in one async task instead of rescheduling task for each one
* Fix regression in http_response - don't overwrite network error code with json parsing error code.