### PR TITLE
Address feedback

### DIFF
--- a/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj
@@ -129,6 +129,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_media_asset.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_progression.cpp" />

--- a/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp">
       <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\club.cpp">
       <Filter>C++ Source\Services\Clubs</Filter>
     </ClCompile>
@@ -914,6 +917,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievements_internal.h">
       <Filter>C++ Source\Services\Achievements</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\clubs_serializers.h">
       <Filter>C++ Source\Services\Clubs</Filter>

--- a/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj
@@ -45,6 +45,8 @@
   </ImportGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_media_asset.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_progression.cpp" />

--- a/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp">
       <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\club.cpp">
       <Filter>C++ Source\Services\Clubs</Filter>
     </ClCompile>
@@ -923,6 +926,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievements_internal.h">
       <Filter>C++ Source\Services\Achievements</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\clubs_serializers.h">
       <Filter>C++ Source\Services\Clubs</Filter>

--- a/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj
@@ -129,6 +129,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_media_asset.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_progression.cpp" />

--- a/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp">
       <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\club.cpp">
       <Filter>C++ Source\Services\Clubs</Filter>
     </ClCompile>
@@ -914,6 +917,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievements_internal.h">
       <Filter>C++ Source\Services\Achievements</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\clubs_serializers.h">
       <Filter>C++ Source\Services\Clubs</Filter>

--- a/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj
@@ -45,6 +45,8 @@
   </ImportGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_media_asset.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievement_progression.cpp" />

--- a/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements.cpp">
       <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.cpp">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\club.cpp">
       <Filter>C++ Source\Services\Clubs</Filter>
     </ClCompile>
@@ -923,6 +926,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\achievements_internal.h">
       <Filter>C++ Source\Services\Achievements</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Achievements\C\achievements_internal_c.h">
+      <Filter>C++ Source\Services\Achievements\C</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Services\Clubs\clubs_serializers.h">
       <Filter>C++ Source\Services\Clubs</Filter>

--- a/InProgressSamples/Social/UWP/C/GameLogic/Game.cpp
+++ b/InProgressSamples/Social/UWP/C/GameLogic/Game.cpp
@@ -737,7 +737,7 @@ void Game::GetUserProfile()
 
         delete asyncBlock;
     };
-    XblProfileGetUserProfile(asyncBlock, m_xboxLiveContext, m_xuid);
+    XblProfileGetUserProfileAsync(asyncBlock, m_xboxLiveContext, m_xuid);
 }
 
 
@@ -777,27 +777,27 @@ void Game::GetSocialRelationships()
     {
         Game *pThis = reinterpret_cast<Game*>(asyncBlock->context);
 
-        size_t size;
-        auto hr = GetAsyncResultSize(asyncBlock, &size);
+        xbl_social_relationship_result_handle resultHandle;
+        auto hr = XblSocialGetSocialRelationshipsResult(asyncBlock, &resultHandle);
 
         if (SUCCEEDED(hr))
         {
-            auto result = (XblSocialRelationshipResult*) malloc(size);
-
-            XblSocialGetSocialRelationshipsResult(asyncBlock, size, result, nullptr);
+            XblSocialRelationship* relationships;
+            uint32_t relationshipCount;
+            XblSocialRelationshipResultGetRelationships(resultHandle, &relationships, &relationshipCount);
 
             std::stringstream ss;
-            ss << "Got social relationships. User has " << result->itemsCount << " relationships:";
+            ss << "Got social relationships. User has " << relationshipCount << " relationships:";
             pThis->Log(ss.str());
 
-            for (unsigned i = 0; i < result->itemsCount; ++i)
+            for (unsigned i = 0; i < relationshipCount; ++i)
             {
                 std::stringstream ss;
-                ss << "Xuid: " << result->items[i].xboxUserId << " isFollowing: " << result->items[i].isFollowingCaller;
-                ss << " isFavorite: " << result->items[i].isFavorite;
+                ss << "Xuid: " << relationships[i].xboxUserId << " isFollowing: " << relationships[i].isFollowingCaller;
+                ss << " isFavorite: " << relationships[i].isFavorite;
                 pThis->Log(ss.str());
             }
-            free(result);
+            XblSocialRelationshipResultCloseHandle(resultHandle);
         }
         else
         {
@@ -805,7 +805,7 @@ void Game::GetSocialRelationships()
         }
     };
 
-    XblSocialGetSocialRelationships(asyncBlock, m_xboxLiveContext, m_xuid, XblSocialRelationshipFilter_All);
+    XblSocialGetSocialRelationshipsAsync(asyncBlock, m_xboxLiveContext, m_xuid, XblSocialRelationshipFilter_All);
 }
 
 void Game::GetAchievmentsForTitle()
@@ -819,17 +819,30 @@ void Game::GetAchievmentsForTitle()
     {
         Game *pThis = reinterpret_cast<Game*>(asyncBlock->context);
 
-        size_t size = 0;
-        auto result = GetAsyncResultSize(asyncBlock, &size);
+        xbl_achievement_result_handle resultHandle;
+        auto hr = XblAchievementsGetAchievementsForTitleIdResult(asyncBlock, &resultHandle);
 
-        if (SUCCEEDED(result))
+        if (SUCCEEDED(hr))
         {
             pThis->Log(L"Successfully got achievements for this title!");
 
-            XblAchievementsResult* achievementsResult = (XblAchievementsResult*)malloc(size);
-            XblAchievementsGetAchievementsForTitleIdResult(asyncBlock, size, achievementsResult, nullptr);
+            XblAchievement* achievements;
+            uint32_t achievementsCount;
+            XblAchievementsResultGetAchievements(resultHandle, &achievements, &achievementsCount);
 
-            pThis->AchievementResultsGetNext(achievementsResult);
+            // Just get/update the first achievement as an example
+            pThis->GetAchievement(achievements[0].serviceConfigurationId, achievements[0].id);
+
+            bool hasNext = false;
+            XblAchievementsResultHasNext(resultHandle, &hasNext);
+            if (hasNext)
+            {
+                pThis->AchievementResultsGetNext(resultHandle);
+            }
+            else
+            {
+                XblAchievementsResultCloseHandle(resultHandle);
+            }
         }
         else
         {
@@ -840,7 +853,7 @@ void Game::GetAchievmentsForTitle()
         delete asyncBlock;
     };
 
-    XblAchievementsGetAchievementsForTitleId(
+    XblAchievementsGetAchievementsForTitleIdAsync(
         asyncBlock,
         m_xboxLiveContext,
         m_xuid,
@@ -852,51 +865,47 @@ void Game::GetAchievmentsForTitle()
         1);
 }
 
-void Game::AchievementResultsGetNext(XblAchievementsResult* result)
+void Game::AchievementResultsGetNext(xbl_achievement_result_handle resultHandle)
 {
-    if (result->hasNext)
+    struct context_t
     {
-        AsyncBlock* asyncBlock = new AsyncBlock{};
-        asyncBlock->queue = m_queue;
-        asyncBlock->context = this;
-        asyncBlock->callback = [](AsyncBlock* asyncBlock)
+        Game* pThis;
+        xbl_achievement_result_handle resultHandle;
+    };
+
+    AsyncBlock* asyncBlock = new AsyncBlock{};
+    asyncBlock->queue = m_queue;
+    asyncBlock->context = new context_t{ this, resultHandle };
+    asyncBlock->callback = [](AsyncBlock* asyncBlock)
+    {
+        auto context = reinterpret_cast<context_t*>(asyncBlock->context);
+        
+        xbl_achievement_result_handle nextResultHandle;
+        auto hr = XblAchievementsResultGetNextResult(asyncBlock, &nextResultHandle);
+
+        if (SUCCEEDED(hr))
         {
-            Game *pThis = reinterpret_cast<Game*>(asyncBlock->context);
+            context->pThis->Log(L"Successfully got next page of achievements!");
+            context->pThis->AchievementResultsGetNext(nextResultHandle);
+            XblAchievementsResultCloseHandle(context->resultHandle);
+        }
+        else
+        {
+            context->pThis->Log(L"Failed getting next page of achievements.");
+        }
 
-            size_t size = 0;
-            auto result = GetAsyncResultSize(asyncBlock, &size);
+        delete asyncBlock->context;
+        delete asyncBlock;
+    };
 
-            if (SUCCEEDED(result))
-            {
-                pThis->Log(L"Successfully got next page of achievements!");
-
-                XblAchievementsResult* achievementsResult = (XblAchievementsResult*)malloc(size);
-                XblAchievementsResultGetNextResult(asyncBlock, size, achievementsResult, nullptr);
-
-                pThis->AchievementResultsGetNext(achievementsResult);
-            }
-            else
-            {
-                pThis->Log(L"Failed getting next page of achievements.");
-                return;
-            }
-
-            delete asyncBlock;
-        };
-
-        XblAchievementsResultGetNext(
-            asyncBlock,
-            m_xboxLiveContext,
-            result,
-            1);
-    }
-    else if (result->itemsCount > 0)
-    {
-        GetAchievement(result->items[0]->serviceConfigurationId, result->items[0]->id);
-    }
+    XblAchievementsResultGetNextAsync(
+        asyncBlock,
+        m_xboxLiveContext,
+        resultHandle,
+        1);
 }
 
-void Game::GetAchievement(PCSTR scid, PCSTR achievementId)
+void Game::GetAchievement(std::string scid, std::string achievementId)
 {
     AsyncBlock* asyncBlock = new AsyncBlock{};
     asyncBlock->queue = m_queue;
@@ -904,21 +913,21 @@ void Game::GetAchievement(PCSTR scid, PCSTR achievementId)
     asyncBlock->callback = [](AsyncBlock* asyncBlock)
     {
         Game *pThis = reinterpret_cast<Game*>(asyncBlock->context);
-        
-        size_t size = 0;
-        auto result = GetAsyncResultSize(asyncBlock, &size);
 
-        if (SUCCEEDED(result))
+        xbl_achievement_result_handle resultHandle;
+        auto hr = XblAchievementsGetAchievementResult(asyncBlock, &resultHandle);
+
+        if (SUCCEEDED(hr))
         {
             pThis->Log(L"Successfully got achievement!");
 
-            XblAchievement* achievement = static_cast<XblAchievement*>(malloc(size));
-            if (achievement != nullptr)
-            {
-                XblAchievementsGetAchievementResult(asyncBlock, size, achievement, nullptr);
+            XblAchievement* achievements;
+            uint32_t achievementsCount;
+            XblAchievementsResultGetAchievements(resultHandle, &achievements, &achievementsCount);
+            assert(achievementsCount == 1);
+            pThis->UpdateAchievement(achievements[0].serviceConfigurationId, achievements[0].id);
 
-                pThis->UpdateAchievement(achievement->serviceConfigurationId, achievement->id);
-            }
+            XblAchievementsResultCloseHandle(resultHandle);
         }
         else
         {
@@ -929,16 +938,16 @@ void Game::GetAchievement(PCSTR scid, PCSTR achievementId)
         delete asyncBlock;
     };
 
-    XblAchievementsGetAchievement(
+    XblAchievementsGetAchievementAsync(
         asyncBlock,
         m_xboxLiveContext,
         m_xuid,
-        scid,
-        achievementId
+        scid.data(),
+        achievementId.data()
         );
 }
 
-void Game::UpdateAchievement(PCSTR scid, PCSTR achievementId)
+void Game::UpdateAchievement(std::string scid, std::string achievementId)
 {
     AsyncBlock* asyncBlock = new AsyncBlock{};
     asyncBlock->queue = m_queue;
@@ -965,13 +974,13 @@ void Game::UpdateAchievement(PCSTR scid, PCSTR achievementId)
     };
 
     auto tid = m_config->titleId;
-    XblAchievementsUpdateAchievement(
+    XblAchievementsUpdateAchievementAsync(
         asyncBlock,
         m_xboxLiveContext,
         m_xuid,
         &tid,
-        scid,
-        achievementId,
+        scid.data(),
+        achievementId.data(),
         10);
 }
 

--- a/InProgressSamples/Social/UWP/C/GameLogic/Game.h
+++ b/InProgressSamples/Social/UWP/C/GameLogic/Game.h
@@ -173,9 +173,9 @@ namespace Sample
 
         // Achievement Tests
         void GetAchievmentsForTitle();
-        void AchievementResultsGetNext(XblAchievementsResult* result);
-        void GetAchievement(PCSTR scid, PCSTR achievementId);
-        void UpdateAchievement(PCSTR scid, PCSTR achievementId);
+        void AchievementResultsGetNext(xbl_achievement_result_handle resultHandle);
+        void GetAchievement(std::string scid, std::string achievementId);
+        void UpdateAchievement(std::string scid, std::string achievementId);
 
         HANDLE m_hBackgroundThread;
     };

--- a/Include/xsapi-c/profile_c.h
+++ b/Include/xsapi-c/profile_c.h
@@ -65,16 +65,16 @@ typedef struct XblUserProfile
 /// <param name="xboxLiveContext">An xbox live context handle created with XblContextCreateHandle.</param>
 /// <param name="xboxUserId">The Xbox User ID of the user to get the profile for.</param>
 /// <remarks>Calls V2 GET /users/batch/profile/settings</remarks>
-STDAPI XblProfileGetUserProfile(
+STDAPI XblProfileGetUserProfileAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t xboxUserId
     ) XBL_NOEXCEPT;
 
 /// <summary>
-/// Get the result for a completed XblProfileGetUserProfile operation
+/// Get the result for a completed XblProfileGetUserProfileAsync operation
 /// </summary>
-/// <param name="async">AsyncBlock from the XblProfileGetUserProfile API.</param>
+/// <param name="async">AsyncBlock from the XblProfileGetUserProfileAsync API.</param>
 /// <param name="profile">Profile object to write result to.</param>
 STDAPI XblProfileGetUserProfileResult(
     _In_ AsyncBlock* async,
@@ -89,7 +89,7 @@ STDAPI XblProfileGetUserProfileResult(
 /// <param name="xboxUserIds">C-style Array of Xbox User IDs of the users to get profiles for.</param>
 /// <param name="xboxUserIdsCount">The number of Xbox User IDs in the array.</param>
 /// <remarks>Calls V2 GET /users/batch/profile/settings</remarks>
-STDAPI XblProfileGetUserProfiles(
+STDAPI XblProfileGetUserProfilesAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t* xboxUserIds,
@@ -97,28 +97,16 @@ STDAPI XblProfileGetUserProfiles(
     ) XBL_NOEXCEPT;
 
 /// <summary>
-/// Get the number of profiles returned from a completed get XblProfileGetUserProfiles operation
-/// </summary>
-/// <param name="async">AsyncBlock from XblProfileGetUserProfiles.</param>
-/// <param name="profileCount">Number of profiles returned.</param>
-STDAPI XblProfileGetUserProfilesResultCount(
-    _In_ AsyncBlock* async,
-    _Out_ uint32_t* profileCount
-    ) XBL_NOEXCEPT;
-
-/// <summary>
-/// Get the result for a completed XblProfileGetUserProfiles operation.
+/// Get the result for a completed XblProfileGetUserProfilesAsync operation.
 /// The number of profiles returned can be obtained with XblGetProfileResultCount.
 /// </summary>
 /// <param name="async">AsyncBlock from XblProfileGetUserProfilesResult.</param>
 /// <param name="profilesCount">Size of the profiles array.</param>
 /// <param name="profiles">Array of XblUserProfile objects to copy result into.</param>
-/// <param name="written">Actual number of profiles written to the array.</param>
 STDAPI XblProfileGetUserProfilesResult(
     _In_ AsyncBlock* async,
     _In_ uint32_t profilesCount,
-    _Out_writes_to_(profilesCount, *written) XblUserProfile* profiles,
-    _Out_opt_ uint32_t* written
+    _Out_writes_(profilesCount) XblUserProfile* profiles
     ) XBL_NOEXCEPT;
 
 /// <summary>
@@ -128,14 +116,14 @@ STDAPI XblProfileGetUserProfilesResult(
 /// <param name="xboxLiveContext">An xbox live context handle created with XblContextCreateHandle.</param>
 /// <param name="socialGroup">The name of the social group of users to search. Options are "Favorites" and "People".</param>
 /// <remarks>Calls V2 GET /users/{userId}/profile/settings/people/{socialGroup}</remarks>
-STDAPI XblProfileGetUserProfilesForSocialGroup(
+STDAPI XblProfileGetUserProfilesForSocialGroupAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ UTF8CSTR socialGroup
     ) XBL_NOEXCEPT;
 
 /// <summary>
-/// Get the number of profiles returned from a completed get XblProfileGetUserProfilesForSocialGroup operation
+/// Get the number of profiles returned from a completed get XblProfileGetUserProfilesForSocialGroupAsync operation
 /// </summary>
 /// <param name="async">AsyncBlock from the get profile API.</param>
 /// <param name="profileCount">Number of profiles returned.</param>
@@ -145,16 +133,14 @@ STDAPI XblProfileGetUserProfilesForSocialGroupResultCount(
     ) XBL_NOEXCEPT;
 
 /// <summary>
-/// Get the result for a completed XblProfileGetUserProfilesForSocialGroup operation.
+/// Get the result for a completed XblProfileGetUserProfilesForSocialGroupAsync operation.
 /// The number of profiles returned can be obtained with XblGetProfileResultCount.
 /// </summary>
-/// <param name="async">AsyncBlock from XblProfileGetUserProfilesForSocialGroup.</param>
+/// <param name="async">AsyncBlock from XblProfileGetUserProfilesForSocialGroupAsync.</param>
 /// <param name="profilesCount">Size of the profiles array.</param>
 /// <param name="profiles">Array of XblUserProfile objects to copy result into.</param>
-/// <param name="written">Actual number of profiles written to the array.</param>
 STDAPI XblProfileGetUserProfilesForSocialGroupResult(
     _In_ AsyncBlock* async,
     _In_ uint32_t profilesCount,
-    _Out_writes_to_(profilesCount, *written) XblUserProfile* profiles,
-    _Out_opt_ uint32_t* written
+    _Out_writes_(profilesCount) XblUserProfile* profiles
     ) XBL_NOEXCEPT;

--- a/Include/xsapi-c/xbox_live_global_c.h
+++ b/Include/xsapi-c/xbox_live_global_c.h
@@ -102,5 +102,6 @@ STDAPI XblGlobalInitialize() XBL_NOEXCEPT;
 /// <summary>
 /// Immediately reclaims all resources associated with the library.
 /// If you called XblMemSetFunctions(), call this before shutting down your app's memory manager.
+/// It is the responsibility of the game to wait for any outstanding Async calls to complete before calling XblGlobalCleanup.
 /// </summary>
 STDAPI_(void) XblGlobalCleanup() XBL_NOEXCEPT;

--- a/Include/xsapi/achievements.h
+++ b/Include/xsapi/achievements.h
@@ -319,7 +319,7 @@ public:
     /// <summary>
     /// The reward type.
     /// </summary>
-    _XSAPIIMP const achievement_reward_type& reward_type() const;
+    _XSAPIIMP achievement_reward_type reward_type() const;
 
     /// <summary>
     /// The property type of the reward value string.
@@ -378,7 +378,7 @@ public:
     /// <summary>
     /// The state of a user's progress towards the earning of the achievement.
     /// </summary>
-    _XSAPIIMP const achievement_progress_state& progress_state() const;
+    _XSAPIIMP achievement_progress_state progress_state() const;
 
     /// <summary>
     /// The progression object containing progress details about the achievement,
@@ -420,12 +420,12 @@ public:
     /// <summary>
     /// The type of achievement, such as a challenge achievement.
     /// </summary>
-    _XSAPIIMP const achievement_type& type() const;
+    _XSAPIIMP achievement_type type() const;
 
     /// <summary>
     /// The participation type for the achievement, such as group or individual.
     /// </summary>
-    _XSAPIIMP const achievement_participation_type& participation_type() const;
+    _XSAPIIMP achievement_participation_type participation_type() const;
 
     /// <summary>
     /// The time window during which the achievement is available. Applies to Challenges.

--- a/Source/Services/Achievements/C/achievements.cpp
+++ b/Source/Services/Achievements/C/achievements.cpp
@@ -3,535 +3,15 @@
 
 #include "pch.h"
 #include "xsapi-c/achievements_c.h"
-#include "Achievements\achievements_internal.h"
+#include "achievements/achievements_internal.h"
 #include "xbox_live_context_internal_c.h"
+#include "achievements_internal_c.h"
 
 using namespace xbox::services;
 using namespace xbox::services::achievements;
 using namespace xbox::services::system;
 
-#pragma region CopyHelpers
-void copy_string(buffer_allocator& allocator, UTF8CSTR* dest, xsapi_internal_string val)
-{
-    *dest = (UTF8CSTR)allocator.alloc(val.size() + 1);
-    memcpy((void*)(*dest), val.c_str(), val.size() + 1);
-}
-
-template<typename Internal, typename FlatC>
-void copy_array(
-    FlatC*** dest,
-    uint64_t* destCount,
-    xsapi_internal_vector<std::shared_ptr<Internal>> source,
-    FlatC*(*copy)(std::shared_ptr<Internal>)
-)
-{
-    size_t neededBufferSize = SizeOfArray(source, count, sizeOfFnc);
-
-    if (neededBufferSize > *bufferSize)
-    {
-        *bufferSize = neededBufferSize;
-        return;
-    }
-
-    T** tempArr = (T**)b.alloc(sizeof(T*) * count);
-    for (size_t i = 0; i < count; ++i)
-    {
-        auto item = (*copy)(source[i], b, bufferSize);
-        tempArr[i] = item;
-    }
-    *dest = tempArr;
-}
-
-template <typename T>
-size_t calculate_array_size(size_t size)
-{
-    size_t neededBufferSize = sizeof(T*) * size;
-    neededBufferSize += sizeof(T) * size;
-    return neededBufferSize;
-}
-
-template <typename T>
-size_t calculate_array_size(xsapi_internal_vector<std::shared_ptr<T>> arr, size_t(*sizeOfFnc)(std::shared_ptr<T>))
-{
-    if (arr.size() == 0) return 0;
-
-    size_t neededBufferSize = sizeof(T*) * arr.size();
-
-    for (size_t i = 0; i < arr.size(); ++i)
-    {
-        neededBufferSize += (*sizeOfFnc)(arr[i]);
-    }
-
-    return neededBufferSize;
-}
-
-template<typename Internal, typename FlatC>
-void copy_array(
-    buffer_allocator& allocator,
-    FlatC*** dest,
-    uint32_t* destCount,
-    xsapi_internal_vector<std::shared_ptr<Internal>> source,
-    FlatC*(*copy)(std::shared_ptr<Internal>, buffer_allocator&)
-)
-{
-    FlatC** tempArr = allocator.alloc_array<FlatC*>((uint32_t)source.size());
-    for (size_t i = 0; i < source.size(); ++i)
-    {
-        tempArr[i] = (*copy)(source[i], allocator);
-    }
-    *dest = tempArr;
-    *destCount = (uint32_t)source.size();
-}
-
-size_t calculate_string_array_size(xsapi_internal_vector<xsapi_internal_string> arr)
-{
-    size_t neededBufferSize = sizeof(UTF8CSTR) * arr.size();
-
-    for (size_t i = 0; i < arr.size(); ++i)
-    {
-        neededBufferSize += arr[i].length() + 1;
-    }
-
-    return neededBufferSize;
-}
-
-void copy_string_array(
-    buffer_allocator& allocator,
-    UTF8CSTR** dest,
-    uint32_t* destCount,
-    xsapi_internal_vector<xsapi_internal_string> source
-)
-{
-    UTF8CSTR* tempArr = allocator.alloc_array<UTF8CSTR>((uint32_t)source.size());
-    for (size_t i = 0; i < source.size(); ++i)
-    {
-        UTF8CSTR copy;
-        copy_string(allocator, &copy, source[i]);
-        tempArr[i] = copy;
-    }
-    *dest = tempArr;
-    *destCount = (uint32_t)source.size();
-}
-
-size_t calculate_achievement_title_association_size(std::shared_ptr<achievement_title_association_internal> source)
-{
-    if (source == nullptr) return 0;
-
-    size_t neededBufferSize = sizeof(XblAchievementTitleAssociation);
-    neededBufferSize += source->name().size() + 1;
-
-    return neededBufferSize;
-}
-
-XblAchievementTitleAssociation* copy_achievement_title_association(
-    std::shared_ptr<achievement_title_association_internal> source,
-    buffer_allocator& allocator
-)
-{
-    if (source == nullptr) return nullptr;
-
-    auto dest = allocator.alloc<XblAchievementTitleAssociation>();
-    copy_string(allocator, &dest->name, source->name());
-    dest->titleId = source->title_id();
-
-    return dest;
-}
-
-size_t calculate_achievement_requirement_size(std::shared_ptr<achievement_requirement_internal> source)
-{
-    if (source == nullptr) return 0;
-
-    size_t neededBufferSize = sizeof(XblAchievementRequirement);
-    neededBufferSize += source->id().size() + 1;
-    neededBufferSize += source->current_progress_value().size() + 1;
-    neededBufferSize += source->target_progress_value().size() + 1;
-
-    return neededBufferSize;
-}
-
-XblAchievementRequirement* copy_achievement_requirement(
-    std::shared_ptr<achievement_requirement_internal> source,
-    buffer_allocator& allocator
-)
-{
-    if (source == nullptr) return nullptr;
-
-    auto dest = allocator.alloc<XblAchievementRequirement>();
-    copy_string(allocator, &dest->id, source->id());
-    copy_string(allocator, &dest->currentProgressValue, source->current_progress_value());
-    copy_string(allocator, &dest->targetProgressValue, source->target_progress_value());
-
-    return dest;
-}
-
-size_t calculate_achievement_media_asset_size(std::shared_ptr<achievement_media_asset_internal> source)
-{
-    if (source == nullptr) return 0;
-
-    size_t neededBufferSize = sizeof(XblAchievementMediaAsset);
-    neededBufferSize += source->name().size() + 1;
-    neededBufferSize += source->url().to_string().size() + 1;
-
-    return neededBufferSize;
-}
-
-XblAchievementMediaAsset* copy_achievement_media_asset(
-    std::shared_ptr<achievement_media_asset_internal> source,
-    buffer_allocator& allocator
-)
-{
-    if (source == nullptr) return nullptr;
-
-    auto dest = allocator.alloc<XblAchievementMediaAsset>();
-    copy_string(allocator, &dest->name, source->name());
-    dest->mediaAssetType = static_cast<XblAchievementMediaAssetType>(source->media_asset_type());
-    copy_string(allocator, &dest->url, utils::internal_string_from_string_t(source->url().to_string()));
-
-    return dest;
-}
-
-size_t calculate_achievement_reward_size(std::shared_ptr<achievement_reward_internal>source)
-{
-    if (source == nullptr) return 0;
-
-    size_t neededBufferSize = sizeof(XblAchievementReward);
-    neededBufferSize += source->name().size() + 1;
-    neededBufferSize += source->description().size() + 1;
-    neededBufferSize += source->value().size() + 1;
-    neededBufferSize += source->value_type().size() + 1;
-
-    if (source->media_asset_internal())
-    {
-        neededBufferSize += calculate_achievement_media_asset_size(source->media_asset_internal());
-    }
-
-    return neededBufferSize;
-}
-
-XblAchievementReward* copy_achievement_reward(
-    std::shared_ptr<achievement_reward_internal> source,
-    buffer_allocator& allocator
-)
-{
-    if (source == nullptr) return nullptr;
-
-    auto dest = allocator.alloc<XblAchievementReward>();
-    copy_string(allocator, &dest->name, source->name());
-    copy_string(allocator, &dest->description, source->description());
-    copy_string(allocator, &dest->value, source->value());
-    dest->rewardType = static_cast<XblAchievementRewardType>(source->reward_type());
-    copy_string(allocator, &dest->valueType, source->value_type());
-    dest->mediaAsset = copy_achievement_media_asset(source->media_asset_internal(), allocator);
-
-    return dest;
-}
-
-size_t calculate_achievement_progression_size(std::shared_ptr<achievement_progression_internal> source)
-{
-    if (source == nullptr) return 0;
-
-    size_t neededBufferSize = sizeof(XblAchievementProgression);
-    neededBufferSize += calculate_array_size(source->requirements(), calculate_achievement_requirement_size);
-
-    return neededBufferSize;
-}
-
-XblAchievementProgression* copy_achievement_progression(
-    std::shared_ptr<achievement_progression_internal> source,
-    buffer_allocator& allocator
-)
-{
-    if (source == nullptr) return nullptr;
-
-    auto dest = allocator.alloc<XblAchievementProgression>();
-    copy_array(allocator, &dest->requirements, &dest->requirementsCount, source->requirements(), copy_achievement_requirement);
-    dest->timeUnlocked = utils::time_t_from_datetime(source->time_unlocked());
-
-    return dest;
-}
-
-size_t calculate_achievement_size(
-    _In_ std::shared_ptr<achievement_internal> source
-)
-{
-    if (source == nullptr) return 0;
-
-    size_t neededBufferSize = sizeof(XblAchievement);
-
-    neededBufferSize += source->id().size() + 1;
-    neededBufferSize += source->service_configuration_id().size() + 1;
-    neededBufferSize += source->name().size() + 1;
-    neededBufferSize += calculate_array_size(source->title_associations(), calculate_achievement_title_association_size);
-    neededBufferSize += calculate_achievement_progression_size(source->progression_internal());
-    neededBufferSize += calculate_array_size(source->media_assets(), calculate_achievement_media_asset_size);
-    neededBufferSize += calculate_string_array_size(source->platforms_available_on());
-    neededBufferSize += source->unlocked_description().size() + 1;
-    neededBufferSize += source->locked_description().size() + 1;
-    neededBufferSize += source->product_id().size() + 1;
-    neededBufferSize += sizeof(XblAchievementTimeWindow);
-    neededBufferSize += calculate_array_size(source->rewards(), calculate_achievement_reward_size);
-    neededBufferSize += source->deep_link().size() + 1;
-
-    return neededBufferSize;
-}
-
-size_t calculate_achievements_result_size(
-    _In_ std::shared_ptr<achievements_result_internal> source
-)
-{
-    size_t neededBufferSize = sizeof(XblAchievementsResult);
-    neededBufferSize += calculate_array_size(source->items(), calculate_achievement_size);
-    neededBufferSize += sizeof(uint32_t) * source->title_ids().size();
-    neededBufferSize += source->continuation_token().size() + 1;
-    return neededBufferSize;
-}
-
-XblAchievement* copy_achievement(
-    std::shared_ptr<achievement_internal> internal,
-    buffer_allocator& allocator
-)
-{
-    if (internal == nullptr) return nullptr;
-
-    auto result = allocator.alloc<XblAchievement>();
-    copy_string(allocator, &result->id, internal->id());
-    copy_string(allocator, &result->serviceConfigurationId, internal->service_configuration_id());
-    copy_string(allocator, &result->name, internal->name());
-    copy_array(allocator, &result->titleAssociations, &result->titleAssociationsCount, internal->title_associations(), copy_achievement_title_association);
-    result->progressState = static_cast<XblAchievementProgressState>(internal->progress_state());
-    result->progression = copy_achievement_progression(internal->progression_internal(), allocator);
-    copy_array(allocator, &result->mediaAssets, &result->mediaAssetsCount, internal->media_assets(), copy_achievement_media_asset);
-    copy_string_array(allocator, &result->platformsAvailableOn, &result->platformsAvailableOnCount, internal->platforms_available_on());
-    result->isSecret = internal->is_secret();
-    copy_string(allocator, &result->unlockedDescription, internal->unlocked_description());
-    copy_string(allocator, &result->lockedDescription, internal->locked_description());
-    copy_string(allocator, &result->productId, internal->product_id());
-    result->type = static_cast<XblAchievementType>(internal->type());
-    result->participationType = static_cast<XblAchievementParticipationType>(internal->participation_type());
-    result->available = allocator.alloc<XblAchievementTimeWindow>();
-    result->available->startDate = utils::time_t_from_datetime(internal->available().start_date());
-    result->available->endDate = utils::time_t_from_datetime(internal->available().end_date());
-    copy_array(allocator, &result->rewards, &result->rewardsCount, internal->rewards(), copy_achievement_reward);
-    result->estimatedUnlockTime = internal->estimated_unlock_time().count();
-    copy_string(allocator, &result->deepLink, internal->deep_link());
-    result->isSecret = internal->is_secret();;
-
-    return result;
-}
-
-XblAchievement* xbl_copy_achievement(
-    _In_ std::shared_ptr<achievement_internal> internal,
-    _In_ size_t bufferSize,
-    _Out_ XblAchievement* achievement
-)
-{
-    buffer_allocator allocator(achievement, bufferSize);
-    return copy_achievement(internal, allocator);
-}
-
-void xbl_copy_achievements_result(
-    _In_ std::shared_ptr<achievements_result_internal> internal,
-    _In_ size_t bufferSize,
-    _Out_ XblAchievementsResult* achievementsResult
-)
-{
-    buffer_allocator allocator(achievementsResult, bufferSize);
-
-    auto result = allocator.alloc<XblAchievementsResult>();
-    copy_array(allocator, &result->items, &result->itemsCount, internal->items(), copy_achievement);
-    result->hasNext = internal->has_next();
-
-    result->xboxUserId = utils::internal_string_to_uint64(internal->xbox_user_id());
-    result->titleIds = allocator.alloc_array<uint32_t>((uint32_t)internal->title_ids().size());
-    result->titleIdsCount = (uint32_t)internal->title_ids().size();
-    for (size_t i = 0; i < internal->title_ids().size(); i++)
-    {
-        result->titleIds[i] = internal->title_ids()[i];
-    }    
-    result->type = static_cast<XblAchievementType>(internal->type());
-    result->unlockedOnly = internal->unlocked_only();
-    result->orderBy = static_cast<XblAchievementOrderBy>(internal->order_by());
-    copy_string(allocator, &result->continuationToken, internal->continuation_token());
-}
-#pragma endregion 
-
-XBL_API bool XBL_CALLING_CONV
-XblAchievementsResultHasNext(
-    _In_ XblAchievementsResult* achievementsResult
-    ) XBL_NOEXCEPT
-try
-{
-    verify_global_init();
-
-    return achievementsResult->continuationToken != nullptr && std::char_traits<xsapi_internal_string::value_type>::length(achievementsResult->continuationToken) > 0;
-}
-CATCH_RETURN_WITH(false)
-
-STDAPI
-XblAchievementsResultGetNext(
-    _In_ AsyncBlock* async,
-    _In_ xbl_context_handle xboxLiveContext,
-    _In_ XblAchievementsResult* achievementsResult,
-    _In_ uint32_t maxItems
-    ) XBL_NOEXCEPT
-try
-{
-    verify_global_init();
-
-    struct Context
-    {
-        XblAchievementsResult* achievementsResult;
-        xbl_context_handle xboxLiveContext;
-        uint32_t maxItems;
-        std::shared_ptr<achievements_result_internal> result;
-    };
-    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context;
-    context->xboxLiveContext = xboxLiveContext;
-    context->maxItems = maxItems;
-    context->achievementsResult = achievementsResult;
-
-    auto hr = BeginAsync(async, context, nullptr, __FUNCTION__,
-        [](AsyncOp op, const AsyncProviderData* data)
-    {
-        auto context = static_cast<Context*>(data->context);
-
-        switch (op)
-        {
-        case AsyncOp_DoWork:
-            context->xboxLiveContext->contextImpl->achievement_service_internal()->get_achievements(
-                utils::uint64_to_internal_string(context->achievementsResult->xboxUserId),
-                utils::uint32_array_to_internal_vector(context->achievementsResult->titleIds, context->achievementsResult->titleIdsCount),
-                static_cast<achievement_type>(context->achievementsResult->type),
-                context->achievementsResult->unlockedOnly,
-                static_cast<achievement_order_by>(context->achievementsResult->orderBy),
-                0, // use continuationToken, ignore skipItems.
-                context->maxItems,
-                context->achievementsResult->continuationToken,
-                data->async->queue,
-                [data, context](xbox_live_result<std::shared_ptr<achievements_result_internal>> result)
-            {
-                context->result = std::move(result.payload());
-                auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
-                CompleteAsync(data->async, hr, calculate_achievements_result_size(context->result));
-            });
-            return E_PENDING;
-
-        case AsyncOp_GetResult:
-            xbl_copy_achievements_result(context->result, data->bufferSize, static_cast<XblAchievementsResult*>(data->buffer));
-            break;
-
-        case AsyncOp_Cleanup:
-            context->~Context();
-            xsapi_memory::mem_free(context);
-            break;
-        }
-        return S_OK;
-    });
-
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-    return ScheduleAsync(async, 0);
-}
-CATCH_RETURN()
-
-STDAPI XblAchievementsUpdateAchievement(
-    _In_ AsyncBlock* async,
-    _In_ xbl_context_handle xboxLiveContext,
-    _In_ uint64_t xboxUserId,
-    _In_opt_ uint32_t* titleId,
-    _In_opt_ UTF8CSTR serviceConfigurationId,
-    _In_ UTF8CSTR achievementId,
-    _In_ uint32_t percentComplete
-    ) XBL_NOEXCEPT
-try
-{
-    verify_global_init();
-
-    struct Context
-    {
-        xbl_context_handle xboxLiveContext;
-        xsapi_internal_string xboxUserId;
-        uint32_t* titleId;
-        xsapi_internal_string serviceConfigurationId;
-        xsapi_internal_string achievementId;
-        uint32_t percentComplete;
-        xbox_live_result<void> result;
-    };
-
-    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context;
-    context->xboxLiveContext = xboxLiveContext;
-    context->xboxUserId = utils::uint64_to_internal_string(xboxUserId);
-    context->titleId = titleId;
-    if (serviceConfigurationId != nullptr)
-    {
-        context->serviceConfigurationId = serviceConfigurationId;
-    }
-    context->achievementId = achievementId;
-    context->percentComplete = percentComplete;
-
-    auto hr = BeginAsync(async, context, nullptr, __FUNCTION__,
-        [](AsyncOp op, const AsyncProviderData* data)
-    {
-        auto context = static_cast<Context*>(data->context);
-
-        switch (op)
-        {
-        case AsyncOp_DoWork:
-
-            if (context->titleId == nullptr)
-            {
-                context->xboxLiveContext->contextImpl->achievement_service_internal()->update_achievement(
-                    context->xboxUserId,
-                    context->achievementId,
-                    context->percentComplete,
-                    data->async->queue,
-                    [data, context](xbox_live_result<void> result) 
-                {
-                    context->result = std::move(result);
-                    auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
-                    CompleteAsync(data->async, hr, 0);
-                });
-            }
-            else
-            {
-                context->xboxLiveContext->contextImpl->achievement_service_internal()->update_achievement(
-                    context->xboxUserId,
-                    *(context->titleId),
-                    context->serviceConfigurationId,
-                    context->achievementId,
-                    context->percentComplete,
-                    data->async->queue,
-                    [data, context](xbox_live_result<void> result)
-                {
-                    context->result = std::move(result);
-                    auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
-                    CompleteAsync(data->async, hr, 0);
-                });
-            }
-            return E_PENDING;
-
-        case AsyncOp_GetResult:
-            break;
-
-        case AsyncOp_Cleanup:
-            context->~Context();
-            xsapi_memory::mem_free(context);
-            break;
-        }
-        return S_OK;
-    });
-
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-    return ScheduleAsync(async, 0);
-}
-CATCH_RETURN()
-
-STDAPI XblAchievementsGetAchievementsForTitleId(
+STDAPI XblAchievementsGetAchievementsForTitleIdAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t xboxUserId,
@@ -556,9 +36,9 @@ try
         XblAchievementOrderBy orderBy;
         uint32_t skipItems;
         uint32_t maxItems;
-        std::shared_ptr<achievements_result_internal> result;
+        xbl_achievement_result_handle resultHandle;
     };
-    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context;
+    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context{};
     context->xboxLiveContext = xboxLiveContext;
     context->xboxUserId = utils::uint64_to_internal_string(xboxUserId);
     context->titleId = titleId;
@@ -587,14 +67,18 @@ try
                 data->async->queue,
                 [data, context](xbox_live_result<std::shared_ptr<achievements_result_internal>> result)
             {
-                context->result = std::move(result.payload());
                 auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
-                CompleteAsync(data->async, hr, calculate_achievements_result_size(context->result));
+                if (SUCCEEDED(hr))
+                {
+                    context->resultHandle = new (xsapi_memory::mem_alloc(sizeof(xbl_achievement_result))) xbl_achievement_result(result.payload());
+                }
+                CompleteAsync(data->async, hr, sizeof(xbl_achievement_result_handle));
             });
             return E_PENDING;
 
         case AsyncOp_GetResult:
-            xbl_copy_achievements_result(context->result, data->bufferSize, static_cast<XblAchievementsResult*>(data->buffer));
+            XSAPI_ASSERT(data->bufferSize == sizeof(xbl_achievement_result_handle));
+            memcpy(data->buffer, &context->resultHandle, sizeof(xbl_achievement_result_handle));
             break;
 
         case AsyncOp_Cleanup:
@@ -613,7 +97,203 @@ try
 }
 CATCH_RETURN()
 
-STDAPI XblAchievementsGetAchievement(
+STDAPI XblAchievementsGetAchievementsForTitleIdResult(
+    _In_ AsyncBlock* async,
+    _Out_ xbl_achievement_result_handle* result
+    ) XBL_NOEXCEPT
+try
+{
+    return GetAsyncResult(async, nullptr, sizeof(xbl_achievement_result_handle), result, nullptr);
+}
+CATCH_RETURN()
+
+STDAPI XblAchievementsResultGetAchievements(
+    _In_ xbl_achievement_result_handle resultHandle,
+    _Out_ XblAchievement** achievements,
+    _Out_ uint32_t* achievementsCount
+    ) XBL_NOEXCEPT
+try
+{
+    RETURN_C_INVALIDARGUMENT_IF(achievementsCount == nullptr || achievements == nullptr || resultHandle == nullptr);
+    verify_global_init();
+
+    *achievementsCount = static_cast<uint32_t>(resultHandle->items.size());
+    *achievements = resultHandle->items.data();
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI XblAchievementsResultHasNext(
+    _In_ xbl_achievement_result_handle resultHandle,
+    _Out_ bool* hasNext
+    ) XBL_NOEXCEPT
+try
+{
+    RETURN_C_INVALIDARGUMENT_IF(resultHandle == nullptr || hasNext == nullptr);
+    verify_global_init();
+    return resultHandle->internalResult != nullptr && resultHandle->internalResult->has_next();
+}
+CATCH_RETURN_WITH(false)
+
+STDAPI
+XblAchievementsResultGetNextAsync(
+    _In_ AsyncBlock* async,
+    _In_ xbl_context_handle xboxLiveContext,
+    _In_ xbl_achievement_result_handle resultHandle,
+    _In_ uint32_t maxItems
+    ) XBL_NOEXCEPT
+try
+{
+    verify_global_init();
+
+    struct Context
+    {
+        xbl_achievement_result_handle inputResultHandle;
+        xbl_context_handle xboxLiveContext;
+        uint32_t maxItems;
+        xbl_achievement_result_handle outputResultHandle;
+    };
+    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context{};
+    context->xboxLiveContext = xboxLiveContext;
+    context->maxItems = maxItems;
+    context->inputResultHandle = resultHandle;
+
+    auto hr = BeginAsync(async, context, nullptr, __FUNCTION__,
+        [](AsyncOp op, const AsyncProviderData* data)
+    {
+        auto context = static_cast<Context*>(data->context);
+
+        switch (op)
+        {
+        case AsyncOp_DoWork:
+            context->inputResultHandle->internalResult->get_next(context->maxItems, data->async->queue,
+                [data, context](xbox_live_result<std::shared_ptr<achievements_result_internal>> result)
+            {
+                auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
+                if (SUCCEEDED(hr))
+                {
+                    context->outputResultHandle = new (xsapi_memory::mem_alloc(sizeof(xbl_achievement_result))) xbl_achievement_result(result.payload());
+                }
+                CompleteAsync(data->async, hr, sizeof(xbl_achievement_result_handle));
+            });
+            return E_PENDING;
+
+        case AsyncOp_GetResult:
+            XSAPI_ASSERT(data->bufferSize == sizeof(xbl_achievement_result_handle));
+            memcpy(data->buffer, &context->outputResultHandle, sizeof(xbl_achievement_result_handle));
+            break;
+
+        case AsyncOp_Cleanup:
+            context->~Context();
+            xsapi_memory::mem_free(context);
+            break;
+        }
+        return S_OK;
+    });
+
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    return ScheduleAsync(async, 0);
+}
+CATCH_RETURN()
+
+STDAPI XblAchievementsResultGetNextResult(
+    _In_ AsyncBlock* async,
+    _Out_ xbl_achievement_result_handle* result
+    ) XBL_NOEXCEPT
+{
+    return GetAsyncResult(async, nullptr, sizeof(xbl_achievement_result_handle), result, nullptr);
+}
+
+STDAPI XblAchievementsUpdateAchievementAsync(
+    _In_ AsyncBlock* async,
+    _In_ xbl_context_handle xboxLiveContext,
+    _In_ uint64_t xboxUserId,
+    _In_opt_ uint32_t* titleId,
+    _In_opt_ UTF8CSTR serviceConfigurationId,
+    _In_ UTF8CSTR achievementId,
+    _In_ uint32_t percentComplete
+    ) XBL_NOEXCEPT
+try
+{
+    verify_global_init();
+
+    struct Context
+    {
+        xbl_context_handle xboxLiveContext;
+        xsapi_internal_string xboxUserId;
+        uint32_t* titleId;
+        xsapi_internal_string serviceConfigurationId;
+        xsapi_internal_string achievementId;
+        uint32_t percentComplete;
+    };
+
+    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context;
+    context->xboxLiveContext = xboxLiveContext;
+    context->xboxUserId = utils::uint64_to_internal_string(xboxUserId);
+    context->titleId = titleId;
+    if (serviceConfigurationId != nullptr)
+    {
+        context->serviceConfigurationId = serviceConfigurationId;
+    }
+    context->achievementId = achievementId;
+    context->percentComplete = percentComplete;
+
+    auto hr = BeginAsync(async, context, nullptr, __FUNCTION__,
+        [](AsyncOp op, const AsyncProviderData* data)
+    {
+        auto context = static_cast<Context*>(data->context);
+
+        switch (op)
+        {
+        case AsyncOp_DoWork:
+            if (context->titleId == nullptr)
+            {
+                context->xboxLiveContext->contextImpl->achievement_service_internal()->update_achievement(
+                    context->xboxUserId,
+                    context->achievementId,
+                    context->percentComplete,
+                    data->async->queue,
+                    [data, context](xbox_live_result<void> result) 
+                {
+                    CompleteAsync(data->async, utils::convert_xbox_live_error_code_to_hresult(result.err()), 0);
+                });
+            }
+            else
+            {
+                context->xboxLiveContext->contextImpl->achievement_service_internal()->update_achievement(
+                    context->xboxUserId,
+                    *(context->titleId),
+                    context->serviceConfigurationId,
+                    context->achievementId,
+                    context->percentComplete,
+                    data->async->queue,
+                    [data, context](xbox_live_result<void> result)
+                {
+                    CompleteAsync(data->async, utils::convert_xbox_live_error_code_to_hresult(result.err()), 0);
+                });
+            }
+            return E_PENDING;
+
+        case AsyncOp_Cleanup:
+            context->~Context();
+            xsapi_memory::mem_free(context);
+            break;
+        }
+        return S_OK;
+    });
+
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    return ScheduleAsync(async, 0);
+}
+CATCH_RETURN()
+
+STDAPI XblAchievementsGetAchievementAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t xboxUserId,
@@ -630,9 +310,9 @@ try
         xsapi_internal_string xboxUserId;
         xsapi_internal_string serviceConfigurationId;
         xsapi_internal_string achievementId;
-        std::shared_ptr<achievement_internal> result;
+        xbl_achievement_result_handle resultHandle;
     };
-    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context;
+    auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context{};
     context->xboxLiveContext = xboxLiveContext;
     context->xboxUserId = utils::uint64_to_internal_string(xboxUserId);
     context->serviceConfigurationId = serviceConfigurationId;
@@ -653,14 +333,18 @@ try
                 data->async->queue,
                 [data, context](xbox_live_result<std::shared_ptr<achievement_internal>> result) 
             {
-                context->result = std::move(result.payload());
                 auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
-                CompleteAsync(data->async, hr, calculate_achievement_size(context->result));
+                if (SUCCEEDED(hr))
+                {
+                    context->resultHandle = new (xsapi_memory::mem_alloc(sizeof(xbl_achievement_result))) xbl_achievement_result(result.payload());
+                }
+                CompleteAsync(data->async, hr, sizeof(xbl_achievement_result_handle));
             });
             return E_PENDING;
 
         case AsyncOp_GetResult:
-            xbl_copy_achievement(context->result, data->bufferSize, static_cast<XblAchievement*>(data->buffer));
+            XSAPI_ASSERT(data->bufferSize == sizeof(xbl_achievement_result_handle));
+            memcpy(data->buffer, &context->resultHandle, sizeof(xbl_achievement_result_handle));
             break;
 
         case AsyncOp_Cleanup:
@@ -681,30 +365,40 @@ CATCH_RETURN()
 
 STDAPI XblAchievementsGetAchievementResult(
     _In_ AsyncBlock* async,
-    _In_ size_t resultSize,
-    _Out_writes_bytes_to_opt_(resultSize, *bufferUsed) XblAchievement* result,
-    _Out_opt_ size_t* bufferUsed
+    _Out_ xbl_achievement_result_handle* result
     ) XBL_NOEXCEPT
+try
 {
-    return GetAsyncResult(async, nullptr, resultSize, result, bufferUsed);
+    return GetAsyncResult(async, nullptr, sizeof(xbl_achievement_result_handle), result, nullptr);
 }
+CATCH_RETURN()
 
-STDAPI XblAchievementsGetAchievementsForTitleIdResult(
-    _In_ AsyncBlock* async,
-    _In_ size_t resultSize,
-    _Out_writes_bytes_to_opt_(resultSize, *bufferUsed) XblAchievementsResult* result,
-    _Out_opt_ size_t* bufferUsed
+STDAPI_(xbl_achievement_result_handle) XblAchievementsResultDuplicateHandle(
+    _In_ xbl_achievement_result_handle handle
     ) XBL_NOEXCEPT
+try
 {
-    return GetAsyncResult(async, nullptr, resultSize, result, bufferUsed);
-}
+    if (handle == nullptr)
+    {
+        return nullptr;
+    }
 
-STDAPI XblAchievementsResultGetNextResult(
-    _In_ AsyncBlock* async,
-    _In_ size_t resultSize,
-    _Out_writes_bytes_to_opt_(resultSize, *bufferUsed) XblAchievementsResult* result,
-    _Out_opt_ size_t* bufferUsed
-    ) XBL_NOEXCEPT
-{
-    return GetAsyncResult(async, nullptr, resultSize, result, bufferUsed);
+    handle->refCount++;
+    return handle;
 }
+CATCH_RETURN_WITH(nullptr)
+
+STDAPI_(void) XblAchievementsResultCloseHandle(
+    _In_ xbl_achievement_result_handle handle
+    ) XBL_NOEXCEPT
+try
+{
+    int refCount = --handle->refCount;
+    if (refCount <= 0)
+    {
+        assert(refCount == 0);
+        handle->~xbl_achievement_result();
+        xsapi_memory::mem_free(handle);
+    }
+}
+CATCH_RETURN_WITH(;)

--- a/Source/Services/Achievements/C/achievements_internal_c.cpp
+++ b/Source/Services/Achievements/C/achievements_internal_c.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pch.h"
+#include "xsapi-c/achievements_c.h"
+#include "achievements/achievements_internal.h"
+#include "achievements_internal_c.h"
+
+using namespace xbox::services;
+using namespace xbox::services::system;
+using namespace xbox::services::achievements;
+
+UTF8STR alloc_and_copy_string(string_t src)
+{
+    auto utf8 = utils::internal_string_from_string_t(src);
+    auto copy = static_cast<UTF8STR>(xsapi_memory::mem_alloc(utf8.size() + 1));
+    strcpy_s(copy, utf8.size() + 1, utf8.data());
+    return copy;
+}
+
+void create_xbl_achievement(
+    _In_ std::shared_ptr<achievement_internal> rhs,
+    _Out_ XblAchievement& lhs
+    )
+{
+    ZeroMemory(&lhs, sizeof(XblAchievement));
+    lhs.id = rhs->id().data();
+    lhs.serviceConfigurationId = rhs->service_configuration_id().data();
+    lhs.name = rhs->name().data();
+    lhs.titleAssociationsCount = static_cast<uint32_t>(rhs->title_associations().size());
+    lhs.titleAssociations = static_cast<XblAchievementTitleAssociation*>(xsapi_memory::mem_alloc(sizeof(XblAchievementTitleAssociation) * lhs.titleAssociationsCount));
+    for (uint32_t j = 0; j < lhs.titleAssociationsCount; ++j)
+    {
+        lhs.titleAssociations[j].name = rhs->title_associations()[j]->name().data();
+        lhs.titleAssociations[j].titleId = rhs->title_associations()[j]->title_id();
+    }
+    lhs.progressState = static_cast<XblAchievementProgressState>(rhs->progress_state());
+    lhs.progression.requirementsCount = static_cast<uint32_t>(rhs->progression_internal()->requirements().size());
+    lhs.progression.requirements = static_cast<XblAchievementRequirement*>(xsapi_memory::mem_alloc(sizeof(XblAchievementRequirement) * lhs.progression.requirementsCount));
+    for (uint32_t j = 0; j < lhs.progression.requirementsCount; ++j)
+    {
+        lhs.progression.requirements[j].id = rhs->progression_internal()->requirements()[j]->id().data();
+        lhs.progression.requirements[j].currentProgressValue = rhs->progression_internal()->requirements()[j]->current_progress_value().data();
+        lhs.progression.requirements[j].targetProgressValue = rhs->progression_internal()->requirements()[j]->target_progress_value().data();
+    }
+    lhs.progression.timeUnlocked = utils::time_t_from_datetime(rhs->progression_internal()->time_unlocked());
+
+    lhs.mediaAssetsCount = static_cast<uint32_t>(rhs->media_assets().size());
+    lhs.mediaAssets = static_cast<XblAchievementMediaAsset*>(xsapi_memory::mem_alloc(sizeof(XblAchievementMediaAsset) * lhs.mediaAssetsCount));
+    for (uint32_t j = 0; j < lhs.mediaAssetsCount; ++j)
+    {
+        lhs.mediaAssets[j].name = rhs->media_assets()[j]->name().data();
+        lhs.mediaAssets[j].mediaAssetType = static_cast<XblAchievementMediaAssetType>(rhs->media_assets()[j]->media_asset_type());
+        lhs.mediaAssets[j].url = alloc_and_copy_string(rhs->media_assets()[j]->url().to_string());
+    }
+
+    lhs.platformsAvailableOnCount = static_cast<uint32_t>(rhs->platforms_available_on().size());
+    lhs.platformsAvailableOn = static_cast<UTF8CSTR*>(xsapi_memory::mem_alloc(sizeof(UTF8CSTR) * lhs.platformsAvailableOnCount));
+    for (uint32_t j = 0; j < lhs.platformsAvailableOnCount; ++j)
+    {
+        lhs.platformsAvailableOn[j] = rhs->platforms_available_on()[j].data();
+    }
+    lhs.isSecret = rhs->is_secret();
+    lhs.unlockedDescription = rhs->unlocked_description().data();
+    lhs.lockedDescription = rhs->locked_description().data();
+    lhs.productId = rhs->product_id().data();
+    lhs.type = static_cast<XblAchievementType>(rhs->type());
+    lhs.participationType = static_cast<XblAchievementParticipationType>(rhs->participation_type());
+    lhs.available.startDate = utils::time_t_from_datetime(rhs->available().start_date());
+    lhs.available.endDate = utils::time_t_from_datetime(rhs->available().end_date());
+
+    lhs.rewardsCount = static_cast<uint32_t>(rhs->rewards().size());
+    lhs.rewards = static_cast<XblAchievementReward*>(xsapi_memory::mem_alloc(sizeof(XblAchievementReward) * lhs.rewardsCount));
+    for (uint32_t j = 0; j < lhs.rewardsCount; ++j)
+    {
+        lhs.rewards[j].name = rhs->rewards()[j]->name().data();
+        lhs.rewards[j].description = rhs->rewards()[j]->description().data();
+        lhs.rewards[j].value = rhs->rewards()[j]->value().data();
+        lhs.rewards[j].rewardType = static_cast<XblAchievementRewardType>(rhs->rewards()[j]->reward_type());
+        lhs.rewards[j].valueType = rhs->rewards()[j]->value_type().data();
+        if (rhs->rewards()[j]->media_asset_internal() != nullptr)
+        {
+            lhs.rewards[j].mediaAsset = static_cast<XblAchievementMediaAsset*>(xsapi_memory::mem_alloc(sizeof(XblAchievementMediaAsset)));
+            lhs.rewards[j].mediaAsset->url = alloc_and_copy_string(rhs->rewards()[j]->media_asset_internal()->url().to_string());
+            lhs.rewards[j].mediaAsset->mediaAssetType = static_cast<XblAchievementMediaAssetType>(rhs->rewards()[j]->media_asset_internal()->media_asset_type());
+            lhs.rewards[j].mediaAsset->name = rhs->rewards()[j]->media_asset_internal()->name().data();
+        }
+        else
+        {
+            lhs.rewards[j].mediaAsset = nullptr;
+        }
+    }
+
+    lhs.estimatedUnlockTime = rhs->estimated_unlock_time().count();
+    lhs.deepLink = rhs->deep_link().data();
+    lhs.isRevoked = rhs->is_revoked();
+}
+
+xbl_achievement_result::xbl_achievement_result(std::shared_ptr<achievements_result_internal> _internalResult)
+    : internalResult(std::move(_internalResult)),
+    internalAchievement(nullptr),
+    refCount(1)
+{
+    auto& internalItems = internalResult->items();
+    items = xsapi_internal_vector<XblAchievement>(internalItems.size());
+
+    for (uint32_t i = 0; i < items.size(); ++i)
+    {
+        create_xbl_achievement(internalItems[i], items[i]);
+    }
+}
+
+xbl_achievement_result::xbl_achievement_result(std::shared_ptr<achievement_internal> _internalAchievement)
+    : internalResult(nullptr),
+    internalAchievement(std::move(_internalAchievement)),
+    refCount(1)
+{
+    items = xsapi_internal_vector<XblAchievement>(1);
+    create_xbl_achievement(internalAchievement, items[0]);
+}
+
+xbl_achievement_result::~xbl_achievement_result()
+{
+    for (auto& item : items)
+    {
+        xsapi_memory::mem_free(item.titleAssociations);
+        xsapi_memory::mem_free(item.progression.requirements);
+        for (uint32_t i = 0; i < item.mediaAssetsCount; ++i)
+        {
+            xsapi_memory::mem_free((void*)item.mediaAssets[i].url);
+        }
+        xsapi_memory::mem_free(item.mediaAssets);
+        xsapi_memory::mem_free(item.platformsAvailableOn);
+        for (uint32_t i = 0; i < item.rewardsCount; ++i)
+        {
+            if (item.rewards[i].mediaAsset != nullptr)
+            {
+                xsapi_memory::mem_free((void*)item.rewards[i].mediaAsset->url);
+                xsapi_memory::mem_free((void*)item.rewards[i].mediaAsset);
+            }
+        }
+        xsapi_memory::mem_free(item.rewards);
+    }
+}

--- a/Source/Services/Achievements/C/achievements_internal_c.h
+++ b/Source/Services/Achievements/C/achievements_internal_c.h
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "achievements/achievements_internal.h"
+
+struct xbl_achievement_result
+{
+    xbl_achievement_result(std::shared_ptr<xbox::services::achievements::achievements_result_internal> _internalResult);
+    xbl_achievement_result(std::shared_ptr<xbox::services::achievements::achievement_internal> _internalAchievement);
+    virtual ~xbl_achievement_result();
+
+    xsapi_internal_vector<XblAchievement> items;
+    std::shared_ptr<xbox::services::achievements::achievements_result_internal> internalResult;
+    std::shared_ptr<xbox::services::achievements::achievement_internal> internalAchievement;
+    std::atomic<int> refCount;
+};

--- a/Source/Services/Achievements/achievement.cpp
+++ b/Source/Services/Achievements/achievement.cpp
@@ -92,7 +92,7 @@ DEFINE_GET_STRING(achievement, id);
 DEFINE_GET_STRING(achievement, service_configuration_id);
 DEFINE_GET_STRING(achievement, name);
 DEFINE_GET_VECTOR_INTERNAL_TYPE(achievement, achievement_title_association, title_associations);
-DEFINE_GET_OBJECT_REF(achievement, achievement_progress_state, progress_state);
+DEFINE_GET_ENUM_TYPE(achievement, achievement_progress_state, progress_state);
 DEFINE_GET_OBJECT_REF(achievement, achievement_progression, progression);
 DEFINE_GET_VECTOR_INTERNAL_TYPE(achievement, achievement_media_asset, media_assets);
 DEFINE_GET_STRING_VECTOR(achievement, platforms_available_on);
@@ -100,8 +100,8 @@ DEFINE_GET_BOOL(achievement, is_secret);
 DEFINE_GET_STRING(achievement, unlocked_description);
 DEFINE_GET_STRING(achievement, locked_description);
 DEFINE_GET_STRING(achievement, product_id);
-DEFINE_GET_OBJECT_REF(achievement, achievement_type, type);
-DEFINE_GET_OBJECT_REF(achievement, achievement_participation_type, participation_type);
+DEFINE_GET_ENUM_TYPE(achievement, achievement_type, type);
+DEFINE_GET_ENUM_TYPE(achievement, achievement_participation_type, participation_type);
 DEFINE_GET_OBJECT_REF(achievement, achievement_time_window, available);
 DEFINE_GET_VECTOR_INTERNAL_TYPE(achievement, achievement_reward, rewards);
 DEFINE_GET_OBJECT_REF(achievement, std::chrono::seconds, estimated_unlock_time);
@@ -184,19 +184,19 @@ achievement_internal::title_associations() const
     return m_titleAssociations;
 }
 
-const achievement_progress_state& 
+achievement_progress_state
 achievement_internal::progress_state() const
 {
     return m_progressState;
 }
 
-const achievement_progression& 
+const achievement_progression&
 achievement_internal::progression() const
 {
     return m_progression;
 }
 
-const std::shared_ptr<achievement_progression_internal>& 
+std::shared_ptr<achievement_progression_internal>
 achievement_internal::progression_internal() const
 {
     return m_progressionInternal;
@@ -238,13 +238,13 @@ achievement_internal::product_id() const
     return m_productId;
 }
 
-const achievement_type& 
+achievement_type
 achievement_internal::type() const
 {
     return m_achievementType;
 }
 
-const achievement_participation_type& 
+achievement_participation_type 
 achievement_internal::participation_type() const
 {
     return m_participationType;

--- a/Source/Services/Achievements/achievement_reward.cpp
+++ b/Source/Services/Achievements/achievement_reward.cpp
@@ -22,7 +22,7 @@ achievement_reward::achievement_reward(
 DEFINE_GET_STRING(achievement_reward, name);
 DEFINE_GET_STRING(achievement_reward, description);
 DEFINE_GET_STRING(achievement_reward, value);
-DEFINE_GET_OBJECT_REF(achievement_reward, achievement_reward_type, reward_type);
+DEFINE_GET_ENUM_TYPE(achievement_reward, achievement_reward_type, reward_type);
 DEFINE_GET_STRING(achievement_reward, value_type);
 DEFINE_GET_OBJECT_REF(achievement_reward, achievement_media_asset, media_asset);
 
@@ -62,7 +62,7 @@ achievement_reward_internal::value() const
     return m_value;
 }
 
-const achievement_reward_type&
+achievement_reward_type
 achievement_reward_internal::reward_type() const
 {
     return m_rewardType;
@@ -80,8 +80,8 @@ achievement_reward_internal::media_asset() const
     return m_mediaAsset;
 }
 
-const std::shared_ptr<achievement_media_asset_internal>&
-achievement_reward_internal::media_asset_internal () const
+std::shared_ptr<achievement_media_asset_internal>
+achievement_reward_internal::media_asset_internal() const
 {
     return m_mediaAssetInternal;
 }

--- a/Source/Services/Achievements/achievements_internal.h
+++ b/Source/Services/Achievements/achievements_internal.h
@@ -114,13 +114,13 @@ public:
 
     const xsapi_internal_string& value() const;
 
-    const achievement_reward_type& reward_type() const;
+    achievement_reward_type reward_type() const;
 
     const xsapi_internal_string& value_type() const;
 
     const achievement_media_asset& media_asset() const;
 
-    const std::shared_ptr<achievement_media_asset_internal>& media_asset_internal() const;
+    std::shared_ptr<achievement_media_asset_internal> media_asset_internal() const;
 
     static xbox_live_result<std::shared_ptr<achievement_reward_internal>> _Deserialize(_In_ const web::json::value& json);
 
@@ -173,11 +173,11 @@ public:
 
     const xsapi_internal_vector<std::shared_ptr<achievement_title_association_internal>>& title_associations() const;
 
-    const achievement_progress_state& progress_state() const;
+    achievement_progress_state progress_state() const;
 
     const achievement_progression& progression() const;
 
-    const std::shared_ptr<achievement_progression_internal>& progression_internal() const;
+    std::shared_ptr<achievement_progression_internal> progression_internal() const;
 
     const xsapi_internal_vector<std::shared_ptr<achievement_media_asset_internal>>& media_assets() const;
 
@@ -191,9 +191,9 @@ public:
 
     const xsapi_internal_string& product_id() const;
 
-    const achievement_type& type() const;
+    achievement_type type() const;
 
-    const achievement_participation_type& participation_type() const;
+    achievement_participation_type participation_type() const;
 
     const achievement_time_window& available() const;
 
@@ -250,8 +250,8 @@ public:
         _In_ achievement_order_by orderBy
     );
 
-    xsapi_internal_vector<std::shared_ptr<achievement_internal>> items() const;
-    
+    const xsapi_internal_vector<std::shared_ptr<achievement_internal>>& items() const;
+
     bool has_next() const;
 
     _XSAPIIMP  xbox_live_result<void> get_next(

--- a/Source/Services/Achievements/achievements_result.cpp
+++ b/Source/Services/Achievements/achievements_result.cpp
@@ -57,7 +57,7 @@ void achievements_result_internal::_Init_next_page_info(
     m_orderBy = orderBy;
 }
 
-xsapi_internal_vector<std::shared_ptr<achievement_internal>>
+const xsapi_internal_vector<std::shared_ptr<achievement_internal>>&
 achievements_result_internal::items() const
 {
     return m_items;

--- a/Source/Services/Social/C/profile.cpp
+++ b/Source/Services/Social/C/profile.cpp
@@ -25,7 +25,7 @@ void copy_profile(
     profile->xboxUserId = utils::internal_string_to_uint64(internal->xbox_user_id());
 }
 
-STDAPI XblProfileGetUserProfile(
+STDAPI XblProfileGetUserProfileAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t xboxUserId
@@ -86,7 +86,7 @@ try
 }
 CATCH_RETURN()
 
-STDAPI XblProfileGetUserProfiles(
+STDAPI XblProfileGetUserProfilesAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t* xboxUserIds,
@@ -153,7 +153,7 @@ try
 }
 CATCH_RETURN()
 
-STDAPI XblProfileGetUserProfilesForSocialGroup(
+STDAPI XblProfileGetUserProfilesForSocialGroupAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ UTF8CSTR socialGroup
@@ -247,8 +247,7 @@ STDAPI XblProfileGetUserProfileResult(
 STDAPI XblProfileGetUserProfilesResult(
     _In_ AsyncBlock* async,
     _In_ uint32_t profilesCount,
-    _Out_writes_to_(profilesCount, *written) XblUserProfile* profiles,
-    _Out_opt_ uint32_t* written
+    _Out_writes_(profilesCount) XblUserProfile* profiles
     ) XBL_NOEXCEPT
 {
     RETURN_C_INVALIDARGUMENT_IF_NULL(async);
@@ -258,10 +257,6 @@ STDAPI XblProfileGetUserProfilesResult(
     RETURN_C_INVALIDARGUMENT_IF(actualProfilesCount > profilesCount);
 
     hr = GetAsyncResult(async, nullptr, profilesCount * sizeof(XblUserProfile), profiles, nullptr);
-    if (SUCCEEDED(hr) && written != nullptr)
-    {
-        *written = actualProfilesCount;
-    }
     return hr;
 }
 
@@ -276,9 +271,8 @@ STDAPI XblProfileGetUserProfilesForSocialGroupResultCount(
 STDAPI XblProfileGetUserProfilesForSocialGroupResult(
     _In_ AsyncBlock* async,
     _In_ uint32_t profilesCount,
-    _Out_writes_to_(profilesCount, *written) XblUserProfile* profiles,
-    _Out_opt_ uint32_t* written
+    _Out_writes_(profilesCount) XblUserProfile* profiles
     ) XBL_NOEXCEPT
 {
-    return XblProfileGetUserProfilesResult(async, profilesCount, profiles, written);
+    return XblProfileGetUserProfilesResult(async, profilesCount, profiles);
 }

--- a/Source/Services/Social/C/social.cpp
+++ b/Source/Services/Social/C/social.cpp
@@ -15,60 +15,42 @@ using namespace xbox::services;
 using namespace xbox::services::system;
 using namespace xbox::services::social;
 
-size_t calculate_social_relationship_result_size(
-    std::shared_ptr<xbox_social_relationship_result_internal> internalResult
-    )
+struct xbl_social_relationship_result
 {
-    size_t requiredSize = sizeof(XblSocialRelationshipResult);
-
-    for (const auto& relationship : internalResult->items())
+    xbl_social_relationship_result(std::shared_ptr<xbox_social_relationship_result_internal> _internalResult)
+        : internalResult(std::move(_internalResult)),
+        refCount(1)
     {
-        requiredSize += sizeof(XblSocialRelationship);
-        for (const auto& socialNetwork : relationship->social_networks())
+        auto& internalItems = internalResult->items();
+        items = xsapi_internal_vector<XblSocialRelationship>(internalItems.size());
+
+        for (uint32_t i = 0; i < items.size(); ++i)
         {
-            requiredSize += sizeof(UTF8CSTR);
-            requiredSize += (socialNetwork.length() + 1);
+            items[i].xboxUserId = utils::internal_string_to_uint64(internalItems[i]->xbox_user_id());
+            items[i].isFavorite = internalItems[i]->is_favorite();
+            items[i].isFollowingCaller = internalItems[i]->is_following_caller();
+            items[i].socialNetworksCount = static_cast<uint32_t>(internalItems[i]->social_networks().size());
+
+            items[i].socialNetworks = (UTF8CSTR*)xsapi_memory::mem_alloc(sizeof(UTF8CSTR) * items[i].socialNetworksCount);
+            for (uint32_t j = 0; j < items[i].socialNetworksCount; ++j)
+            {
+                items[i].socialNetworks[j] = internalItems[i]->social_networks()[j].data();
+            }
         }
     }
-    return requiredSize;
-}
 
-void copy_social_relationship_result(
-    _In_ std::shared_ptr<xbox_social_relationship_result_internal> internal,
-    _In_ size_t bufferSize,
-    _Out_ XblSocialRelationshipResult* buffer
-    )
-{
-    buffer_allocator allocator(buffer, bufferSize);
-
-    auto result = allocator.alloc<XblSocialRelationshipResult>();
-    result->itemsCount = (uint32_t)internal->items().size();
-    result->totalCount = internal->total_count();
-    result->hasNext = internal->has_next();
-    result->filter = static_cast<XblSocialRelationshipFilter>(internal->filter());
-    result->continuationSkip = internal->continuation_skip();
-    result->items = allocator.alloc_array<XblSocialRelationship>((uint32_t)internal->items().size());
-
-    // populate the relationships
-    uint32_t i = 0;
-    for (const auto& relationship : internal->items())
+    virtual ~xbl_social_relationship_result()
     {
-        result->items[i].isFavorite = relationship->is_favorite();
-        result->items[i].isFollowingCaller = relationship->is_following_caller();
-        result->items[i].socialNetworksCount = (uint32_t)relationship->social_networks().size();
-        result->items[i].xboxUserId = utils::internal_string_to_uint64(relationship->xbox_user_id());
-        result->items[i].socialNetworks = allocator.alloc_array<UTF8CSTR>(result->items[i].socialNetworksCount);
-
-        for (uint32_t j = 0; j < result->items[i].socialNetworksCount; ++j)
+        for (auto& item : items)
         {
-            auto& socialNetwork = relationship->social_networks()[j];
-            auto length = socialNetwork.length() + 1;
-            result->items[i].socialNetworks[j] = (UTF8CSTR)allocator.alloc(length);
-            memcpy((void*)result->items[i].socialNetworks[j], socialNetwork.data(), length);
+            xsapi_memory::mem_free(item.socialNetworks);
         }
-        i++;
     }
-}
+
+    xsapi_internal_vector<XblSocialRelationship> items;
+    std::shared_ptr<xbox_social_relationship_result_internal> internalResult;
+    std::atomic<int> refCount;
+};
 
 STDAPI XblGetSocialRelationshipsHelper(
     _In_ AsyncBlock* async,
@@ -88,7 +70,7 @@ STDAPI XblGetSocialRelationshipsHelper(
         XblSocialRelationshipFilter filter;
         uint32_t startIndex;
         uint32_t maxItems;
-        std::shared_ptr<xbox_social_relationship_result_internal> result;
+        xbl_social_relationship_result_handle resultHandle;
     };
 
     auto context = new (xsapi_memory::mem_alloc(sizeof(Context))) Context
@@ -116,14 +98,18 @@ STDAPI XblGetSocialRelationshipsHelper(
                 data->async->queue,
                 [data, context](xbox_live_result<std::shared_ptr<xbox_social_relationship_result_internal>> result)
             {
-                context->result = result.payload();
                 auto hr = utils::convert_xbox_live_error_code_to_hresult(result.err());
-                CompleteAsync(data->async, hr, calculate_social_relationship_result_size(context->result));
+                if (SUCCEEDED(hr))
+                {
+                    context->resultHandle = new (xsapi_memory::mem_alloc(sizeof(xbl_social_relationship_result))) xbl_social_relationship_result(result.payload());
+                }
+                CompleteAsync(data->async, hr, sizeof(xbl_social_relationship_result_handle));
             });
             return E_PENDING;
 
         case AsyncOp_GetResult:
-            copy_social_relationship_result(context->result, data->bufferSize, static_cast<XblSocialRelationshipResult*>(data->buffer));
+            XSAPI_ASSERT(data->bufferSize == sizeof(xbl_social_relationship_result_handle));
+            memcpy(data->buffer, &context->resultHandle, sizeof(xbl_social_relationship_result_handle));
             break;
 
         case AsyncOp_Cleanup:
@@ -141,7 +127,7 @@ STDAPI XblGetSocialRelationshipsHelper(
     return ScheduleAsync(async, 0);
 }
 
-STDAPI XblSocialGetSocialRelationships(
+STDAPI XblSocialGetSocialRelationshipsAsync(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
     _In_ uint64_t xboxUserId,
@@ -160,42 +146,102 @@ try
 }
 CATCH_RETURN()
 
+STDAPI XblSocialRelationshipResultGetRelationships(
+    _In_ xbl_social_relationship_result_handle resultHandle,
+    _Out_ XblSocialRelationship** relationships,
+    _Out_ uint32_t* relationshipsCount
+    ) XBL_NOEXCEPT
+try
+{
+    RETURN_C_INVALIDARGUMENT_IF(resultHandle == nullptr || relationships == nullptr || relationshipsCount == nullptr);
+    verify_global_init();
+
+    *relationshipsCount = static_cast<uint32_t>(resultHandle->items.size());
+    *relationships = resultHandle->items.data();
+    return S_OK;
+}
+CATCH_RETURN()
+
+STDAPI XblSocialRelationshipResultHasNext(
+    _In_ xbl_social_relationship_result_handle resultHandle,
+    _Out_ bool* hasNext
+    ) XBL_NOEXCEPT
+try
+{
+    RETURN_C_INVALIDARGUMENT_IF(resultHandle == nullptr || hasNext == nullptr);
+    verify_global_init();
+    return resultHandle->internalResult->has_next();
+}
+CATCH_RETURN()
+
 STDAPI XblSocialRelationshipResultGetNext(
     _In_ AsyncBlock* async,
     _In_ xbl_context_handle xboxLiveContext,
-    _In_ CONST XblSocialRelationshipResult *socialRelationshipResult,
+    _In_ xbl_social_relationship_result_handle resultHandle,
     _In_ uint32_t maxItems
     ) XBL_NOEXCEPT
+try
 {
     return XblGetSocialRelationshipsHelper(
         async,
         xboxLiveContext,
         xboxLiveContext->xboxUserId,
-        socialRelationshipResult->filter,
-        socialRelationshipResult->continuationSkip,
+        static_cast<XblSocialRelationshipFilter>(resultHandle->internalResult->filter()),
+        resultHandle->internalResult->continuation_skip(),
         maxItems
         );
 }
+CATCH_RETURN()
 
 STDAPI XblSocialGetSocialRelationshipsResult(
     _In_ AsyncBlock* async,
-    _In_ size_t bufferSize,
-    _Out_writes_bytes_to_opt_(bufferSize, *bufferUsed) XblSocialRelationshipResult* buffer,
-    _Out_opt_ size_t* bufferUsed
+    _Out_ xbl_social_relationship_result_handle* handle
     ) XBL_NOEXCEPT
+try
 {
-    return GetAsyncResult(async, nullptr, bufferSize, buffer, bufferUsed);
+    return GetAsyncResult(async, nullptr, sizeof(xbl_social_relationship_result_handle), handle, nullptr);
 }
+CATCH_RETURN()
 
 STDAPI XblSocialRelationshipResultGetNextResult(
     _In_ AsyncBlock* async,
-    _In_ size_t bufferSize,
-    _Out_writes_bytes_to_opt_(bufferSize, *bufferUsed) XblSocialRelationshipResult* buffer,
-    _Out_opt_ size_t* bufferUsed
+    _Out_ xbl_social_relationship_result_handle* handle
     ) XBL_NOEXCEPT
+try
 {
-    return GetAsyncResult(async, nullptr, bufferSize, buffer, bufferUsed);
+    return GetAsyncResult(async, nullptr, sizeof(xbl_social_relationship_result_handle), handle, nullptr);
 }
+CATCH_RETURN()
+
+STDAPI_(xbl_social_relationship_result_handle) XblSocialRelationshipResultDuplicateHandle(
+    _In_ xbl_social_relationship_result_handle handle
+    ) XBL_NOEXCEPT
+try
+{
+    if (handle == nullptr)
+    {
+        return nullptr;
+    }
+
+    handle->refCount++;
+    return handle;
+}
+CATCH_RETURN_WITH(nullptr)
+
+STDAPI_(void) XblSocialRelationshipResultCloseHandle(
+    _In_ xbl_social_relationship_result_handle handle
+    ) XBL_NOEXCEPT
+try
+{
+    int refCount = --handle->refCount;
+    if (refCount <= 0)
+    {
+        assert(refCount == 0);
+        handle->~xbl_social_relationship_result();
+        xsapi_memory::mem_free(handle);
+    }
+}
+CATCH_RETURN_WITH(;)
 
 STDAPI XblSocialSubscribeToSocialRelationshipChange(
     _In_ xbl_context_handle xboxLiveContext,

--- a/Source/Shared/utils.cpp
+++ b/Source/Shared/utils.cpp
@@ -1124,7 +1124,7 @@ utils::convert_xbox_live_error_code_to_hresult(
     {
         return __HRESULT_FROM_WIN32(ERROR_RESOURCE_DATA_NOT_FOUND);
     }
-    else if (err >= 400 && err <= 505)
+    else if (err >= 300 && err <= 505)
     {
         return convert_http_status_to_hresult(err);
     }

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -636,6 +636,8 @@ set(Social_Manager_Source_Files_C
 
 set(Achievements_Source_Files_C
     ../../Source/Services/Achievements/C/achievements.cpp
+    ../../Source/Services/Achievements/C/achievements_internal_c.h
+    ../../Source/Services/Achievements/C/achievements_internal_c.cpp
     )
 
 


### PR DESCRIPTION
* Addressing feedback from API review
* Async APIs that return complex, variably sized objects should instead return a handle and manage the memory of the object internally.  The internal memory is freed with a new close handle API.
* Add "Async" to name of all Async API's