### PR TITLE
Fixing Async cleanup issues

### DIFF
--- a/Source/Shared/call_buffer_timer.cpp
+++ b/Source/Shared/call_buffer_timer.cpp
@@ -118,7 +118,7 @@ call_buffer_timer::fire_helper(
         async->context = utils::store_shared_ptr(contextSharedPtr);
         async->callback = [](AsyncBlock* async)
         {
-            auto context = utils::remove_shared_ptr<fire_context>(async->context);
+            auto context = utils::get_shared_ptr<fire_context>(async->context);
             std::shared_ptr<call_buffer_timer> pThis(context->thisWeak.lock());
             if (pThis != nullptr)
             {
@@ -139,7 +139,7 @@ call_buffer_timer::fire_helper(
         {
             if (op == AsyncOp_DoWork)
             {
-                auto context = static_cast<fire_context*>(data->context);
+                auto context = utils::get_shared_ptr<fire_context>(data->context, false);
 
                 std::shared_ptr<call_buffer_timer> pThis(context->thisWeak.lock());
                 if (pThis != nullptr)

--- a/Source/Shared/http_call_impl.cpp
+++ b/Source/Shared/http_call_impl.cpp
@@ -438,7 +438,7 @@ void http_call_impl::handle_unauthorized_error(
             else
             {
                 // if getting a new token failed, then we need to just return the 401 upwards
-                utils::remove_shared_ptr<http_call_data>(context, true);
+                utils::get_shared_ptr<http_call_data>(context, true);
                 httpCallResponse->route_service_call();
                 httpCallData->callback(httpCallResponse);
             }
@@ -460,7 +460,7 @@ void http_call_impl::internal_get_response(
     asyncBlock->context = utils::store_shared_ptr(httpCallData);
     asyncBlock->callback = [](_In_ AsyncBlock* asyncBlock)
     {
-        auto httpCallData = utils::remove_shared_ptr<http_call_data>(asyncBlock->context, false);
+        auto httpCallData = utils::get_shared_ptr<http_call_data>(asyncBlock->context, false);
         auto httpCallResponse = xsapi_allocate_shared<http_call_response_internal>(httpCallData);
 
         void* context = asyncBlock->context;
@@ -480,7 +480,7 @@ void http_call_impl::internal_get_response(
                 handle_throttle_error(httpCallResponse, httpCallData);
             }
 
-            utils::remove_shared_ptr<http_call_data>(context, true);
+            utils::get_shared_ptr<http_call_data>(context, true);
             httpCallResponse->route_service_call();
             httpCallData->callback(httpCallResponse);
         }

--- a/Source/Shared/user_context_winrt.cpp
+++ b/Source/Shared/user_context_winrt.cpp
@@ -68,7 +68,7 @@ void get_auth_result(
     async->context = utils::store_shared_ptr(context);
     async->callback = [](AsyncBlock* async)
     {
-        auto context = utils::remove_shared_ptr<auth_context>(async->context);
+        auto context = utils::get_shared_ptr<auth_context>(async->context);
         context->callback(context->result);
         xsapi_memory::mem_free(async);
     };
@@ -82,7 +82,7 @@ void get_auth_result(
         switch (op)
         {
         case AsyncOp_DoWork:
-            context = utils::remove_shared_ptr<auth_context>(data->context, false);
+            context = utils::get_shared_ptr<auth_context>(data->context, false);
             if (context->requestBodyString != nullptr)
             {
                 asyncOp = context->user->GetTokenAndSignatureAsync(

--- a/Source/Shared/utils.cpp
+++ b/Source/Shared/utils.cpp
@@ -115,14 +115,6 @@ xsapi_singleton::~xsapi_singleton()
     std::lock_guard<std::mutex> guard(s_xsapiSingletonLock);
     s_xsapiSingleton = nullptr;
 
-    if (m_callbackContextPtrs.size() > 0)
-    {
-#if _DEBUG && UNIT_TEST_SERVICES
-        assert(false && "Context remaining in context store!");
-#endif
-        m_callbackContextPtrs.clear();
-    }
-
     HCCleanup();
 
     CloseAsyncQueue(m_asyncQueue);

--- a/Source/Shared/web_socket_client.cpp
+++ b/Source/Shared/web_socket_client.cpp
@@ -121,7 +121,7 @@ void xbox_web_socket_client::connect(
         {
             WebSocketCompletionResult result = {};
             HCGetWebSocketConnectResult(asyncBlock, &result);
-            auto callback = utils::remove_shared_ptr<xbox_live_callback<WebSocketCompletionResult>>(asyncBlock->context);
+            auto callback = utils::get_shared_ptr<xbox_live_callback<WebSocketCompletionResult>>(asyncBlock->context);
             (*callback)(result);
             xsapi_memory::mem_free(asyncBlock);
         };
@@ -141,7 +141,7 @@ void xbox_web_socket_client::send(
     {
         WebSocketCompletionResult result = {};
         HCGetWebSocketSendMessageResult(asyncBlock, &result);
-        auto callback = utils::remove_shared_ptr<xbox_live_callback<WebSocketCompletionResult>>(asyncBlock->context);
+        auto callback = utils::get_shared_ptr<xbox_live_callback<WebSocketCompletionResult>>(asyncBlock->context);
         (*callback)(result);
         xsapi_memory::mem_free(asyncBlock);
     };

--- a/Source/Shared/web_socket_connection.cpp
+++ b/Source/Shared/web_socket_connection.cpp
@@ -157,7 +157,7 @@ void web_socket_connection::ensure_connected()
     BeginAsync(outerAsync, utils::store_shared_ptr(retryContext), nullptr, __FUNCTION__,
         [](_In_ AsyncOp op, _In_ const AsyncProviderData* data)
     {
-        auto context = utils::remove_shared_ptr<retry_context>(data->context, op == AsyncOp_Cleanup);
+        auto context = utils::get_shared_ptr<retry_context>(data->context, op == AsyncOp_Cleanup);
         context->asyncProviderData = data;
 
         switch (op)

--- a/Source/System/user_impl_idp.cpp
+++ b/Source/System/user_impl_idp.cpp
@@ -239,7 +239,7 @@ void user_impl_idp::initialize_provider(
     async->context = utils::store_shared_ptr(xsapi_allocate_shared<xbox_live_callback<void>>(callback));
     async->callback = [](AsyncBlock* async)
     {
-        auto callbackPtr = utils::remove_shared_ptr<xbox_live_callback<void>>(async->context);
+        auto callbackPtr = utils::get_shared_ptr<xbox_live_callback<void>>(async->context);
         (*callbackPtr)();
         xsapi_memory::mem_free(async);
     };
@@ -249,9 +249,7 @@ void user_impl_idp::initialize_provider(
     {
         if (op == AsyncOp_DoWork)
         {
-            auto thisWeakPtr = utils::remove_weak_ptr<user_impl_idp>(data->context);
-            auto thisPtr = thisWeakPtr.lock();
-
+            auto thisPtr = utils::get_shared_ptr<user_impl_idp>(data->context);
             if (thisPtr == nullptr || thisPtr->m_provider != nullptr)
             {
                 CompleteAsync(data->async, S_OK, 0);
@@ -354,7 +352,7 @@ void user_impl_idp::internal_get_token_and_signature(
     internalAsyncBlock->queue = queue;
     internalAsyncBlock->callback = [](_In_ struct AsyncBlock* asyncBlock)
     {
-        auto context = utils::remove_shared_ptr<get_token_and_signature_context>(asyncBlock->context, true);
+        auto context = utils::get_shared_ptr<get_token_and_signature_context>(asyncBlock->context, true);
         context->callback(context->result);
         xsapi_memory::mem_free(asyncBlock);
     };
@@ -368,7 +366,7 @@ void user_impl_idp::internal_get_token_and_signature(
         switch (op)
         {
         case AsyncOp_DoWork:
-            context = utils::remove_shared_ptr<get_token_and_signature_context>(data->context, false);
+            context = utils::get_shared_ptr<get_token_and_signature_context>(data->context, false);
             pThis = std::dynamic_pointer_cast<user_impl_idp>(context->userImpl);
 
             context->result = pThis->internal_get_token_and_signature_helper(

--- a/Tests/UnitTests/Mocks/StockMocks.cpp
+++ b/Tests/UnitTests/Mocks/StockMocks.cpp
@@ -301,7 +301,7 @@ void StockMocks::AddHttpMockResponse(
     )
 {
     // TODO move
-    HCInitialize();
+    HCInitialize(nullptr);
 
     hc_mock_call_handle mockCall;
 


### PR DESCRIPTION
* Changing how store_shared_ptr works so that it isn't dependent on singleton being alive when async tasks complete
* Remove outer async task for a couple of periodic tasks in social manager since we don't actually care when then they periodic tasks are done