### PR TITLE
Make sure C headers compile with C compiler

### DIFF
--- a/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj
@@ -435,7 +435,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\system_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.cpp" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\auth_config.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\auth_config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h" />

--- a/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.140.UWP.Cpp/Microsoft.Xbox.Services.140.UWP.Cpp.vcxproj.filters
@@ -766,6 +766,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.cpp">
       <Filter>C++ Source\System\C</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp">
+      <Filter>C++ Source\System\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\token_and_signature_result.cpp">
       <Filter>C++ Source\System</Filter>
     </ClCompile>
@@ -1068,7 +1071,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\system_c.h">
       <Filter>C++ Source\System\C</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.h">
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h">
       <Filter>C++ Source\System\C</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h">

--- a/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj
@@ -355,6 +355,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_service_call_routed_event_args_internal.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\system_internal.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\xbox_live_mutex.cpp" />
@@ -459,6 +461,7 @@
       $(ProjectDir)..\..\Source\Services\Clubs;
       $(ProjectDir)..\..\Source\Shared;
       $(ProjectDir)..\..\Source\System;
+      $(ProjectDir)..\..\Source\System\C;
       $(ProjectDir)..\..\Source\;
       $(ProjectDir)..\..\Include;
       $(ProjectDir)..\..\External\cpprestsdk\Release\include;

--- a/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.140.XDK.Cpp/Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj.filters
@@ -784,6 +784,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.cpp">
       <Filter>C++ Source\Shared</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp">
+      <Filter>C++ Source\System\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\xbox_live_mutex.cpp">
       <Filter>C++ Source\System</Filter>
     </ClCompile>
@@ -1065,6 +1068,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.h">
       <Filter>C++ Source\Shared</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h">
+      <Filter>C++ Source\System\C</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h">
       <Filter>C++ Source\System</Filter>
     </ClInclude>
@@ -1168,6 +1174,9 @@
     </Filter>
     <Filter Include="C++ Source\System">
       <UniqueIdentifier>{726C90DE-90DC-36A6-B559-090139CBCAD4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="C++ Source\System\C">
+      <UniqueIdentifier>{ADE29175-A900-335D-8BEE-020474634852}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Build/Microsoft.Xbox.Services.140.XDK.WinRT/Microsoft.Xbox.Services.140.XDK.WinRT.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.140.XDK.WinRT/Microsoft.Xbox.Services.140.XDK.WinRT.vcxproj.filters
@@ -2370,145 +2370,145 @@
   </ItemGroup>
   <ItemGroup>
     <Filter Include="C++ Public Includes">
-      <UniqueIdentifier>{848B0C02-35A1-3A9D-81CC-513FF3F205BB}</UniqueIdentifier>
+      <UniqueIdentifier>{3DE8CCA4-8E4A-3583-A3BE-7A6401156977}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source">
-      <UniqueIdentifier>{C156B2C1-D13C-31D8-8955-CFD94B05A781}</UniqueIdentifier>
+      <UniqueIdentifier>{AFCC838D-D7FF-37A0-A511-3F4CB2127DCB}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services">
-      <UniqueIdentifier>{66EEBBE9-943D-3582-8058-538D12E44C73}</UniqueIdentifier>
+      <UniqueIdentifier>{7AD88441-A4AD-368B-AF0C-5AF02B604837}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Achievements">
-      <UniqueIdentifier>{944DCCD5-BE38-3EF1-8751-B67A25DEE141}</UniqueIdentifier>
+      <UniqueIdentifier>{8FC7F5B8-D8DB-32F1-BE20-8B7E608F529E}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Achievements\WinRT">
-      <UniqueIdentifier>{5300601B-5D19-3DA5-8BF9-3D394A0CCE4F}</UniqueIdentifier>
+      <UniqueIdentifier>{A2F8B26F-ECE9-3465-8792-7642143BEB21}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Clubs">
-      <UniqueIdentifier>{4544D624-4272-3396-A7C6-D5B0291B41C6}</UniqueIdentifier>
+      <UniqueIdentifier>{4DDFC8A5-0A32-33A3-B56A-EF057C1E8BCE}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Clubs\WinRT">
-      <UniqueIdentifier>{FFC1B215-A9A0-311B-B66E-73342A2B0521}</UniqueIdentifier>
+      <UniqueIdentifier>{CE6EF1ED-7054-3DA7-9944-C0027A467544}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Common">
-      <UniqueIdentifier>{EC7FB0B8-2870-322C-A888-BF97E9F2F231}</UniqueIdentifier>
+      <UniqueIdentifier>{72F9FCDF-3BCF-3EC0-AF83-57BBB2FBB5BD}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Common\WinRT">
-      <UniqueIdentifier>{038CAE7E-05AF-331C-B658-977DD2E76B65}</UniqueIdentifier>
+      <UniqueIdentifier>{77048C85-EAFA-38DB-AB69-AA0F15A7ECF0}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\EntertainmentProfile">
-      <UniqueIdentifier>{C3EF846E-2B89-3268-BDF3-297B1FF30022}</UniqueIdentifier>
+      <UniqueIdentifier>{87B22C65-826B-35A5-940A-B54044DB6E24}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\EntertainmentProfile\WinRT">
-      <UniqueIdentifier>{EEABD1E4-8870-321A-81AD-87423BDF6868}</UniqueIdentifier>
+      <UniqueIdentifier>{3209EEF6-060A-3D4C-8181-023E64860A69}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\GameServerPlatform">
-      <UniqueIdentifier>{8F4A8E1F-8415-3656-B646-A59C8EEA0241}</UniqueIdentifier>
+      <UniqueIdentifier>{693D54D5-5339-359C-8609-79662C786C85}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\GameServerPlatform\WinRT">
-      <UniqueIdentifier>{855825D5-C60A-390C-A925-A947E172C2CD}</UniqueIdentifier>
+      <UniqueIdentifier>{3B7CEEE3-C2E2-37AC-AFAC-1C8F09221C0B}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Leaderboard">
-      <UniqueIdentifier>{8BCC6200-A2AA-35D5-8419-768DFB76293A}</UniqueIdentifier>
+      <UniqueIdentifier>{B0CF46AB-1659-31A6-8C02-83B4564E3819}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Leaderboard\WinRT">
-      <UniqueIdentifier>{6BBAEB81-C095-3A68-BA9A-9F254399F9D3}</UniqueIdentifier>
+      <UniqueIdentifier>{5781FE07-781B-30BF-A1BD-98E12CF0F0B8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Marketplace">
-      <UniqueIdentifier>{E666A459-C521-327E-91C0-E95357F5268D}</UniqueIdentifier>
+      <UniqueIdentifier>{02DEA4D2-1C94-399C-B9B0-54E4C2A38014}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Marketplace\WinRT">
-      <UniqueIdentifier>{4C47A1D9-B79E-335A-BF53-B293843954B9}</UniqueIdentifier>
+      <UniqueIdentifier>{A6E26631-9EB6-32DD-B2E8-18FABC0A60D2}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Matchmaking">
-      <UniqueIdentifier>{CE5C21E4-A2E5-3E52-BA16-687703199D04}</UniqueIdentifier>
+      <UniqueIdentifier>{271EFB0E-1724-31AF-9899-817AEF07EC87}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Matchmaking\WinRT">
-      <UniqueIdentifier>{458043D0-B977-358F-AE22-DA2D1E406689}</UniqueIdentifier>
+      <UniqueIdentifier>{DD72A891-968F-3527-80DB-AA153B82A1C8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Misc">
-      <UniqueIdentifier>{206338C2-9047-3AAE-B89B-A141CD0A774F}</UniqueIdentifier>
+      <UniqueIdentifier>{49DC8300-5A37-3137-B6FA-783A9DCB5BD2}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Misc\WinRT">
-      <UniqueIdentifier>{7AFE8ACD-0281-3A4B-9DBA-5858473AE2AE}</UniqueIdentifier>
+      <UniqueIdentifier>{F5C3962D-9676-3111-A9D8-592C596F06D7}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Multiplayer">
-      <UniqueIdentifier>{99823FCB-D3ED-3A5D-B62C-320A9D786606}</UniqueIdentifier>
+      <UniqueIdentifier>{A504F8B9-CC91-32AB-88AC-D74B4FB97B0A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Multiplayer\Manager">
-      <UniqueIdentifier>{93130BC3-2203-3733-B903-28CDDEEEF42A}</UniqueIdentifier>
+      <UniqueIdentifier>{AC112783-E43F-3E4D-B710-D206C3058EFC}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Multiplayer\Manager\WinRT">
-      <UniqueIdentifier>{D345D0F4-C8AE-3FC9-8407-F16991A1B220}</UniqueIdentifier>
+      <UniqueIdentifier>{BD58092C-206A-3C8B-8DA5-B5E4B01F1CA4}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Multiplayer\WinRT">
-      <UniqueIdentifier>{CFE0BB67-2571-3F89-8826-2744B01FEE7D}</UniqueIdentifier>
+      <UniqueIdentifier>{BD1F8F68-774C-3470-9038-2C9A0EA30F12}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Presence">
-      <UniqueIdentifier>{5017E436-F879-3FF1-BCAD-83B4C72A2292}</UniqueIdentifier>
+      <UniqueIdentifier>{24F9FA17-9826-3C02-9CA4-B67E07024D09}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Presence\WinRT">
-      <UniqueIdentifier>{FD9E1975-DABA-36D3-9EBD-3C703AB30056}</UniqueIdentifier>
+      <UniqueIdentifier>{8F27C59D-8BCB-32AE-B8E1-308D5AC15ECB}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Privacy">
-      <UniqueIdentifier>{49F10E9A-819C-3954-B991-180F11B46226}</UniqueIdentifier>
+      <UniqueIdentifier>{CF9F3F58-E7B3-30D1-9819-AB77E10A84FA}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Privacy\WinRT">
-      <UniqueIdentifier>{1F48107E-7574-33AC-AD47-758133406AA2}</UniqueIdentifier>
+      <UniqueIdentifier>{FDB309FF-81AF-3C94-9140-2DFD09A2F202}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\RTA">
-      <UniqueIdentifier>{FC0030F7-3F0D-3EFA-9646-AF5EB6399395}</UniqueIdentifier>
+      <UniqueIdentifier>{A7557710-5DA2-3B35-B64E-6057FB400A84}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\RTA\WinRT">
-      <UniqueIdentifier>{253DBB04-D90F-3EA6-AC9B-4D54664C1EC8}</UniqueIdentifier>
+      <UniqueIdentifier>{304F598A-63C3-3A8D-AF10-E1CF6595C6A1}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Social">
-      <UniqueIdentifier>{2EC6F0EB-F705-3F60-82EC-D9E20529347D}</UniqueIdentifier>
+      <UniqueIdentifier>{AA84E8CC-7F03-3DB0-9298-91F25994A8A8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Social\Manager">
-      <UniqueIdentifier>{432888EB-664F-3B60-A937-CEC66EB64B1A}</UniqueIdentifier>
+      <UniqueIdentifier>{0311E669-4A78-3C49-A288-9B2EEB0CEE0A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Social\Manager\WinRT">
-      <UniqueIdentifier>{4DA1880C-C4F4-3B20-BA51-0277E9CB333F}</UniqueIdentifier>
+      <UniqueIdentifier>{EFEAD5CC-4871-3576-8299-23BA737AB25C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Social\WinRT">
-      <UniqueIdentifier>{4FB2B169-B069-38ED-9ECE-FA4333EC6D3D}</UniqueIdentifier>
+      <UniqueIdentifier>{7884D36F-E4C3-39DE-8DB4-0F7D0397A9E8}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Stats">
-      <UniqueIdentifier>{1DA27FD2-950D-35B3-8628-88F1AED33D47}</UniqueIdentifier>
+      <UniqueIdentifier>{DD13831D-24DF-3B79-B767-37AEFB76D89A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Stats\Manager">
-      <UniqueIdentifier>{57A0A6E0-3E99-371E-952D-38DECAC4B717}</UniqueIdentifier>
+      <UniqueIdentifier>{3268C79E-5C62-32E6-B85E-E72BA5A0A251}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Stats\Manager\WinRT">
-      <UniqueIdentifier>{765859F5-D852-3E9E-964C-318C91E48306}</UniqueIdentifier>
+      <UniqueIdentifier>{238C7C7A-1BE0-30B3-8A2A-ACC6864DCE94}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Stats\WinRT">
-      <UniqueIdentifier>{B5694E76-E2FA-3451-8387-701C5F3AD66D}</UniqueIdentifier>
+      <UniqueIdentifier>{D5192824-85D7-3035-A427-C82C3504848A}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\TitleStorage">
-      <UniqueIdentifier>{BC1BDE36-893F-3602-9627-CA4C4527DE0E}</UniqueIdentifier>
+      <UniqueIdentifier>{2344B338-A5E4-3667-A052-7EAD0AC11FC5}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\TitleStorage\WinRT">
-      <UniqueIdentifier>{757C10D1-92D5-38B4-995A-EA73F4CF9C14}</UniqueIdentifier>
+      <UniqueIdentifier>{49B0BE95-2699-3BCF-85C2-92269AC9624C}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Tournaments">
-      <UniqueIdentifier>{07AFE11C-DC40-366D-8518-3C19089D73FF}</UniqueIdentifier>
+      <UniqueIdentifier>{35CE6E19-6E09-3D12-B275-D3D6DB6097BF}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Services\Tournaments\WinRT">
-      <UniqueIdentifier>{65B87542-CA15-3C8C-85ED-FF0C33879C25}</UniqueIdentifier>
+      <UniqueIdentifier>{595707F3-7EC8-3652-A7D4-0EC90AFFF5A0}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Shared">
-      <UniqueIdentifier>{B682A27C-50BA-30B6-9573-26F7B62C7BD5}</UniqueIdentifier>
+      <UniqueIdentifier>{4B225209-5709-3A59-81F9-27B50CED1B10}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Shared\Logger">
-      <UniqueIdentifier>{D30FEB85-D0C6-32DE-B1BB-75623BAC93C3}</UniqueIdentifier>
+      <UniqueIdentifier>{6356990A-FB32-312F-BDA4-177C7F312F3B}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\Shared\WinRT">
-      <UniqueIdentifier>{5C1BFE08-AE36-31F1-9696-DB526AD4D90E}</UniqueIdentifier>
+      <UniqueIdentifier>{0BDEF81A-5EA8-31DE-9C02-320FA1D36334}</UniqueIdentifier>
     </Filter>
     <Filter Include="C++ Source\System">
-      <UniqueIdentifier>{D75844CD-55A8-3AB4-ABC1-4028BC89E81D}</UniqueIdentifier>
+      <UniqueIdentifier>{726C90DE-90DC-36A6-B559-090139CBCAD4}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj
@@ -435,7 +435,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\system_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.cpp" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\auth_config.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\auth_config.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h" />

--- a/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.141.UWP.Cpp/Microsoft.Xbox.Services.141.UWP.Cpp.vcxproj.filters
@@ -766,6 +766,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.cpp">
       <Filter>C++ Source\System\C</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp">
+      <Filter>C++ Source\System\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\token_and_signature_result.cpp">
       <Filter>C++ Source\System</Filter>
     </ClCompile>
@@ -1068,7 +1071,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\system_c.h">
       <Filter>C++ Source\System\C</Filter>
     </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_c.h">
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h">
       <Filter>C++ Source\System\C</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h">

--- a/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj
+++ b/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj
@@ -355,6 +355,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_service_call_routed_event_args_internal.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.cpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.h" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\system_internal.h" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\xbox_live_mutex.cpp" />
@@ -458,6 +460,7 @@
       $(ProjectDir)..\..\Source\Services\GameServerPlatform;
       $(ProjectDir)..\..\Source\Shared;
       $(ProjectDir)..\..\Source\System;
+      $(ProjectDir)..\..\Source\System\C;
       $(ProjectDir)..\..\Source\;
       $(ProjectDir)..\..\Include;
       $(ProjectDir)..\..\External\cpprestsdk\Release\include;

--- a/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj.filters
+++ b/Build/Microsoft.Xbox.Services.141.XDK.Cpp/Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj.filters
@@ -784,6 +784,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.cpp">
       <Filter>C++ Source\Shared</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.cpp">
+      <Filter>C++ Source\System\C</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\Source\System\xbox_live_mutex.cpp">
       <Filter>C++ Source\System</Filter>
     </ClCompile>
@@ -1065,6 +1068,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\Shared\xbox_system_factory.h">
       <Filter>C++ Source\Shared</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\C\user_internal_c.h">
+      <Filter>C++ Source\System\C</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\Source\System\ppltasks_extra.h">
       <Filter>C++ Source\System</Filter>
     </ClInclude>
@@ -1168,6 +1174,9 @@
     </Filter>
     <Filter Include="C++ Source\System">
       <UniqueIdentifier>{726C90DE-90DC-36A6-B559-090139CBCAD4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="C++ Source\System\C">
+      <UniqueIdentifier>{ADE29175-A900-335D-8BEE-020474634852}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/InProgressSamples/Social/Xbox/C/SocialManagerIntegration.cpp
+++ b/InProgressSamples/Social/Xbox/C/SocialManagerIntegration.cpp
@@ -12,6 +12,11 @@ using namespace Windows::Foundation;
 using namespace xbox::services;
 using namespace xbox::services::social::manager;
 
+IInspectable* AsInspectable(Platform::Object^ object)
+{
+    return reinterpret_cast<IInspectable*>(object);
+}
+
 void
 Game::InitializeSocialManager(Windows::Foundation::Collections::IVectorView<Windows::Xbox::System::User^>^ userList)
 {

--- a/InProgressSamples/Social/Xbox/C/SocialManagerIntegration.cpp
+++ b/InProgressSamples/Social/Xbox/C/SocialManagerIntegration.cpp
@@ -35,7 +35,7 @@ Game::AddUserToSocialManager(
         source << _T(" to SocialManager");
         Log(source.str());
 
-        XblSocialManagerAddLocalUser(user, XblSocialManagerExtraDetailLevel_All);
+        XblSocialManagerAddLocalUser(AsInspectable(user), XblSocialManagerExtraDetailLevel_All);
         m_userAdded = true;
     }
 
@@ -55,10 +55,12 @@ Game::RemoveUserFromSocialManager(
     source << _T(" from SocialManager");
     Log(source.str());
 
+    auto inspectable = AsInspectable(user);
+
     auto it = m_socialGroups.begin();
     while (it != m_socialGroups.end()) 
     {
-        if (wcscmp((*it)->localUser->XboxUserId->Data(), user->XboxUserId->Data()))
+        if ((*it)->localUser == inspectable)
         {
             it = m_socialGroups.erase(it);
         }
@@ -67,7 +69,7 @@ Game::RemoveUserFromSocialManager(
             ++it;
         }
     }
-    XblSocialManagerRemoveLocalUser(user);
+    XblSocialManagerRemoveLocalUser(inspectable);
 }
 
 void 
@@ -78,7 +80,7 @@ Game::CreateSocialGroupFromList(
 {
     for (auto group : m_socialGroups)
     {
-        if (group->socialUserGroupType == XblSocialUserGroupType_UserListType && group->localUser == user)
+        if (group->socialUserGroupType == XblSocialUserGroupType_UserListType && group->localUser == AsInspectable(user))
         {
             XblSocialManagerUpdateSocialUserGroup(group, xuidList.data(), (uint32_t)xuidList.size());
             return;
@@ -88,7 +90,7 @@ Game::CreateSocialGroupFromList(
     if( xuidList.size() > 0 )
     {
         XblSocialManagerUserGroup *newGroup;
-        auto hr = XblSocialManagerCreateSocialUserGroupFromList(user, xuidList.data(), (uint32_t)xuidList.size(), &newGroup);
+        auto hr = XblSocialManagerCreateSocialUserGroupFromList(AsInspectable(user), xuidList.data(), (uint32_t)xuidList.size(), &newGroup);
         if (SUCCEEDED(hr))
         {
             m_socialGroups.push_back(newGroup);
@@ -104,7 +106,7 @@ Game::CreateSocialGroupFromFilters(
     )
 {
     XblSocialManagerUserGroup *newGroup;
-    auto hr = XblSocialManagerCreateSocialUserGroupFromFilters(user, presenceFilter, relationshipFilter, &newGroup);
+    auto hr = XblSocialManagerCreateSocialUserGroupFromFilters(AsInspectable(user), presenceFilter, relationshipFilter, &newGroup);
 
     if (SUCCEEDED(hr))
     {
@@ -122,7 +124,7 @@ Game::DestorySocialGroup(
     auto it = m_socialGroups.begin();
     while (it != m_socialGroups.end())
     {
-        if ((*it)->localUser == user && (*it)->socialUserGroupType == XblSocialUserGroupType_UserListType)
+        if ((*it)->localUser == AsInspectable(user) && (*it)->socialUserGroupType == XblSocialUserGroupType_UserListType)
         {
             XblSocialManagerDestroySocialUserGroup(*it);
             it = m_socialGroups.erase(it);
@@ -147,7 +149,7 @@ Game::DestroySocialGroup(
     while (it != m_socialGroups.end())
     {
         auto group = *it;
-        if (group->localUser == user &&
+        if (group->localUser == AsInspectable(user) &&
             group->presenceFilterOfGroup == presenceFilter &&
             group->relationshipFilterOfGroup == relationshipFilter)
         {

--- a/InProgressSamples/Social/Xbox/C/Support/Game.cpp
+++ b/InProgressSamples/Social/Xbox/C/Support/Game.cpp
@@ -396,7 +396,7 @@ void Game::UpdateSocialGroupForAllUsers(
 }
 
 void Game::UpdateSocialGroup(
-    _In_ xbl_user_handle user,
+    _In_ Windows::Xbox::System::User^ user,
     _In_ bool toggle,
     _In_ XblPresenceFilter presenceFilter,
     _In_ XblRelationshipFilter relationshipFilter

--- a/InProgressSamples/Social/Xbox/C/Support/Game.h
+++ b/InProgressSamples/Social/Xbox/C/Support/Game.h
@@ -167,11 +167,6 @@ private:
         _In_ Windows::Xbox::System::User^ user,
         _In_ bool toggle
         );
-
-    IInspectable* AsInspectable(Platform::Object^ object)
-    {
-        return reinterpret_cast<IInspectable*>(object);
-    }
 };
 
 extern Game* g_sampleInstance;

--- a/InProgressSamples/Social/Xbox/C/Support/Game.h
+++ b/InProgressSamples/Social/Xbox/C/Support/Game.h
@@ -168,6 +168,10 @@ private:
         _In_ bool toggle
         );
 
+    IInspectable* AsInspectable(Platform::Object^ object)
+    {
+        return reinterpret_cast<IInspectable*>(object);
+    }
 };
 
 extern Game* g_sampleInstance;

--- a/Include/xsapi-c/errors_c.h
+++ b/Include/xsapi-c/errors_c.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
-#include "pal.h"
 
 /// <summary>
 /// Enumeration values that define the Xbox Live API error conditions.

--- a/Include/xsapi-c/pal.h
+++ b/Include/xsapi-c/pal.h
@@ -118,7 +118,7 @@ typedef int32_t function_context;
 typedef struct xbl_xbox_live_context* xbl_context_handle;
 
 #if XDK_API
-typedef Windows::Xbox::System::User^ xbl_user_handle;
+typedef struct IInspectable* xbl_user_handle;
 #else
 typedef struct xbl_xbox_live_user* xbl_user_handle;
 #endif

--- a/Include/xsapi-c/presence_c.h
+++ b/Include/xsapi-c/presence_c.h
@@ -3,9 +3,6 @@
 
 #pragma once
 
-#include "pal.h"
-#include "xsapi-c/errors_c.h"
-
 /// <summary>Defines values used to indicate the device type associate with an XblSocialManagerPresenceTitleRecord.</summary>
 typedef enum XblPresenceDeviceType
 {

--- a/Include/xsapi-c/social_manager_c.h
+++ b/Include/xsapi-c/social_manager_c.h
@@ -3,10 +3,6 @@
 
 #pragma once
 
-#include "pal.h"
-#include "xsapi-c/errors_c.h"
-#include "xsapi-c/presence_c.h"
-
 typedef enum XblSocialManagerExtraDetailLevel 
 {
     /// <summary>Only get default PeopleHub information (presence, profile)</summary>

--- a/Include/xsapi-c/xbox_live_app_config_c.h
+++ b/Include/xsapi-c/xbox_live_app_config_c.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
-#include <stdint.h>
-#include "pal.h"
 
 /// <summary>
 /// Represents the configuration of an Xbox Live application.

--- a/Include/xsapi-c/xbox_live_context_c.h
+++ b/Include/xsapi-c/xbox_live_context_c.h
@@ -2,14 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
-#include "pal.h"
 
 struct XblAppConfig;
 
 /// <summary>
 /// Creates an xbl_context_handle used to access Xbox Live services.
 /// </summary>
-/// <param name="user">The Xbox Live user associated with this context.</param>
+/// <param name="user">
+/// The Xbox Live user associated with this context. For XDK this should be an IInspectable pointer
+/// to a Windows::Xbox::System::User.
+/// </param>
 /// <param name="context">The returned Xbox Live context handle.</param>
 /// <returns>Result code for this API operation.</returns>
 STDAPI XblContextCreateHandle(

--- a/Include/xsapi-c/xbox_live_context_settings_c.h
+++ b/Include/xsapi-c/xbox_live_context_settings_c.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma once
-#include "pal.h"
 
 const uint32_t XBL_MAXIMUM_WEBSOCKETS_ACTIVATIONS_ALLOWED_PER_USER = 5;
 

--- a/Source/Services/Common/C/xbox_live_context_c.cpp
+++ b/Source/Services/Common/C/xbox_live_context_c.cpp
@@ -4,9 +4,7 @@
 #include "pch.h"
 #include "xsapi-c/xbox_live_app_config_c.h"
 #include "xsapi-c/xbox_live_context_c.h"
-#if !XDK_API
-#include "user_c.h"
-#endif
+#include "user_internal_c.h"
 #include "xbox_live_context_internal_c.h"
 #include "user_context.h"
 

--- a/Source/Services/Common/C/xbox_live_context_internal_c.h
+++ b/Source/Services/Common/C/xbox_live_context_internal_c.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include "xbox_live_context_impl.h"
+#include "user_internal_c.h"
 #if !XDK_API
 #include "system_c.h"
-#include "user_c.h"
 #include "user_impl.h"
 #endif
 
@@ -18,8 +18,9 @@ struct xbl_xbox_live_context
         contextImpl(nullptr)
     {
 #if XDK_API
-        xboxUserIdString = xbox::services::utils::internal_string_from_utf16(user->XboxUserId->Data());
-        contextImpl = xsapi_allocate_shared<xbox::services::xbox_live_context_impl>(_user);
+        userInternal = get_user_from_user_handle(user);
+        xboxUserIdString = xbox::services::utils::internal_string_from_utf16(userInternal->XboxUserId->Data());
+        contextImpl = xsapi_allocate_shared<xbox::services::xbox_live_context_impl>(userInternal);
 #else
         xboxUserIdString = user->userImpl->xbox_user_id();
         contextImpl = xsapi_allocate_shared<xbox::services::xbox_live_context_impl>(user->internalUser);
@@ -28,8 +29,12 @@ struct xbl_xbox_live_context
         contextImpl->init();
     }
 
-
-    xbl_user_handle user;
+#if XDK_API
+    IInspectable* user;
+    Windows::Xbox::System::User^ userInternal;
+#else
+    xbl_xbox_live_user* user;
+#endif
     std::shared_ptr<xbox::services::xbox_live_context_impl> contextImpl;
     xsapi_internal_string xboxUserIdString;
     uint64_t xboxUserId;

--- a/Source/System/C/user_c.cpp
+++ b/Source/System/C/user_c.cpp
@@ -223,7 +223,7 @@ HRESULT SignInHelper(
         switch (op)
         {
         case AsyncOp_DoWork:
-            context = utils::remove_shared_ptr<SignInContext>(data->context, false);
+            context = utils::get_shared_ptr<SignInContext>(data->context, false);
 
             context->user->userImpl->sign_in_impl(context->showUi, false, data->async->queue,
                 [data, context](xbox_live_result<sign_in_result> result)
@@ -235,13 +235,13 @@ HRESULT SignInHelper(
             return E_PENDING;
 
         case AsyncOp_GetResult:
-            context = utils::remove_shared_ptr<SignInContext>(data->context, false);
+            context = utils::get_shared_ptr<SignInContext>(data->context, false);
             result.status = static_cast<XblSignInStatus>(context->result.payload().status());
             CopyMemory(data->buffer, &result, sizeof(XblSignInResult));
             break;
 
         case AsyncOp_Cleanup:
-            utils::remove_shared_ptr<SignInContext>(data->context);
+            utils::get_shared_ptr<SignInContext>(data->context);
             break;
         }
         return S_OK;
@@ -346,7 +346,7 @@ try
         switch (op)
         {
         case AsyncOp_DoWork:
-            std::shared_ptr<GetTokenAndSignatureContext> context = utils::remove_shared_ptr<GetTokenAndSignatureContext>(data->context);
+            std::shared_ptr<GetTokenAndSignatureContext> context = utils::get_shared_ptr<GetTokenAndSignatureContext>(data->context);
 
             context->user->userImpl->get_token_and_signature(context->httpMethod, 
                 context->url, 

--- a/Source/System/C/user_c.cpp
+++ b/Source/System/C/user_c.cpp
@@ -4,11 +4,12 @@
 #include "pch.h"
 #include "system_c.h"
 #include "user_impl.h"
-#include "user_c.h"
+#include "user_internal_c.h"
 
 using namespace xbox::services;
 using namespace xbox::services::system;
 
+#if !XDK_API
 STDAPI
 XblUserCreateHandleFromSystemUser(
     _In_opt_ Windows::System::User^ creationContext,
@@ -413,3 +414,4 @@ try
     xbox_live_user::remove_sign_out_completed_handler(context);
 }
 CATCH_RETURN_WITH(;)
+#endif // !XDK_API

--- a/Source/System/C/user_internal_c.cpp
+++ b/Source/System/C/user_internal_c.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pch.h"
+#include "user_internal_c.h"
+
+xbox_live_user_t get_user_from_user_handle(xbl_user_handle userHandle)
+{
+#if XDK_API
+    IID xboxSystemUserIID = { 0xA2C2223E, 0x2F00, 0x44E2,{ 0x89, 0x7E, 0x01, 0x5B, 0xCE, 0xB8, 0x77, 0x17 } };
+    Windows::Xbox::System::User^ user;
+    auto hr = userHandle->QueryInterface(xboxSystemUserIID, (void**)&user);
+    if (SUCCEEDED(hr))
+    {
+        return user;
+    }
+    else
+    {
+        return nullptr;
+    }
+#else
+    return userHandle->internalUser;
+#endif
+}
+
+#if XDK_API
+xbl_user_handle get_user_handle_from_user(xbox_live_user_t user)
+{
+    return reinterpret_cast<IInspectable*>(static_cast<Platform::Object^>(user));
+}
+#endif

--- a/Source/System/C/user_internal_c.h
+++ b/Source/System/C/user_internal_c.h
@@ -3,6 +3,12 @@
 
 #pragma once
 
+xbox_live_user_t get_user_from_user_handle(xbl_user_handle userHandle);
+#if XDK_API
+xbl_user_handle get_user_handle_from_user(xbox_live_user_t user);
+#endif
+
+#if !XDK_API
 struct xbl_xbox_live_user
 {
     xbl_xbox_live_user(_In_opt_ Windows::System::User^ creationContext)
@@ -30,3 +36,4 @@ struct xbl_xbox_live_user
     std::shared_ptr<xbox::services::system::user_impl> userImpl;
     std::atomic<int> refCount;
 };
+#endif

--- a/Source/System/user_impl_idp.cpp
+++ b/Source/System/user_impl_idp.cpp
@@ -275,6 +275,7 @@ void user_impl_idp::initialize_provider(
                 }
 
                 AsyncBlock* async = data->async;
+                std::weak_ptr<user_impl_idp> thisWeakPtr(thisPtr);
                 asyncOp->Completed = ref new AsyncOperationCompletedHandler<WebAccountProvider^>(
                     [thisWeakPtr, async](IAsyncOperation<WebAccountProvider^>^ asyncInfo, Windows::Foundation::AsyncStatus status)
                 {

--- a/Utilities/CMake/CMakeLists.txt
+++ b/Utilities/CMake/CMakeLists.txt
@@ -231,7 +231,7 @@ if( UNITTEST )
         Shared_Logger_Source_Files	
         ../../Source/Shared/Logger/console_output.cpp
         ../../Source/Shared/Logger/console_output.h
-        )		
+        )
 endif()
 
 set(UWP_Shared_Source_Files
@@ -610,8 +610,12 @@ set(Clubs_Source_Files
 
 set(UWP_System_Source_Files_C
     ../../Source/System/C/system_c.h
-    ../../Source/System/C/user_c.h
     ../../Source/System/C/user_c.cpp
+    )
+
+set(System_Source_Files_C
+    ../../Source/System/C/user_internal_c.h
+    ../../Source/System/C/user_internal_c.cpp
     )
 
 set(Shared_Source_Files_C
@@ -1286,6 +1290,7 @@ else()
 		source_group("C++ Source\\Services\\Tournaments\\WinRT" FILES ${Tournaments_WinRT_Source_Files})
         source_group("C++ Source\\Services\\Clubs\\WinRT" FILES ${Clubs_WinRT_Source_Files})
     else()
+        source_group("C++ Source\\System\\C" FILES ${System_Source_Files_C})
         source_group("C++ Source\\Shared\\C" FILES ${Shared_Source_Files_C})
         source_group("C++ Source\\Services\\Achievements\\C" FILES ${Achievements_Source_Files_C})
         source_group("C++ Source\\Services\\Common\\C" FILES ${Common_Source_Files_C})

--- a/Utilities/CMake/template-Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj
+++ b/Utilities/CMake/template-Microsoft.Xbox.Services.140.XDK.Cpp.vcxproj
@@ -97,6 +97,7 @@
       $(ProjectDir)..\..\Source\Services\Clubs;
       $(ProjectDir)..\..\Source\Shared;
       $(ProjectDir)..\..\Source\System;
+      $(ProjectDir)..\..\Source\System\C;
       $(ProjectDir)..\..\Source\;
       $(ProjectDir)..\..\Include;
       $(ProjectDir)..\..\External\cpprestsdk\Release\include;

--- a/Utilities/CMake/template-Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj
+++ b/Utilities/CMake/template-Microsoft.Xbox.Services.141.XDK.Cpp.vcxproj
@@ -96,6 +96,7 @@
       $(ProjectDir)..\..\Source\Services\GameServerPlatform;
       $(ProjectDir)..\..\Source\Shared;
       $(ProjectDir)..\..\Source\System;
+      $(ProjectDir)..\..\Source\System\C;
       $(ProjectDir)..\..\Source\;
       $(ProjectDir)..\..\Include;
       $(ProjectDir)..\..\External\cpprestsdk\Release\include;


### PR DESCRIPTION
Removes caret hat types from C headers and replace them with IInspectable pointers so that the headers are actually usable in a pure C environment. 