### PR TITLE
Expose to the end user control over which qos endpoint to use.

### DIFF
--- a/Include/xsapi/xbox_live_context_settings.h
+++ b/Include/xsapi/xbox_live_context_settings.h
@@ -312,7 +312,7 @@ private:
     std::chrono::seconds m_websocketTimeoutWindow;
     bool m_useCoreDispatcherForEventRouting;
 	
-	bool m_useXplatQosServer;
+    bool m_useXplatQosServer;
 };
 
 

--- a/Include/xsapi/xbox_live_context_settings.h
+++ b/Include/xsapi/xbox_live_context_settings.h
@@ -276,6 +276,17 @@ public:
         _In_ xbox_live_context_recommended_setting setting
         );
 
+	/// <summary>
+	/// Gets whether to use the xplatqos server for qos calls.
+	/// </summary>
+	_XSAPIIMP bool use_crossplatform_qos_servers() const;
+
+	/// <summary>
+	/// Controls whether we use cross platform qos endpoints or not.
+	/// In some case if you are shipping with TV_API enabled, you want to be able to choose.
+	/// </summary>
+	_XSAPIIMP void set_use_crossplatform_qos_servers(_In_ bool value);
+
 public:
     // Internal public function
 #if UWP_API || UNIT_TEST_SERVICES
@@ -300,6 +311,8 @@ private:
 
     std::chrono::seconds m_websocketTimeoutWindow;
     bool m_useCoreDispatcherForEventRouting;
+	
+	bool m_useXplatQosServer;
 };
 
 

--- a/Source/Services/GameServerPlatform/game_server_platform_service.cpp
+++ b/Source/Services/GameServerPlatform/game_server_platform_service.cpp
@@ -253,15 +253,27 @@ game_server_platform_service::get_game_server_metadata(
 pplx::task<xbox::services::xbox_live_result<std::vector<quality_of_service_server>>>
 game_server_platform_service::get_quality_of_service_servers()
 {
+
+	string_t path;
+	
+	if (m_xboxLiveContextSettings)
+	{
+		path = m_xboxLiveContextSettings->use_crossplatform_qos_servers() ? _T("/xplatqosservers") : _T("/qosservers");
+	}
+	else
+	{
+#if TV_API
+		path = _T("/qosservers");
+#else
+		path = _T("/xplatqosservers");
+#endif
+	}
+
     std::shared_ptr<http_call> httpCall = xbox::services::system::xbox_system_factory::get_factory()->create_http_call(
         m_xboxLiveContextSettings,
         _T("GET"),
         utils::create_xboxlive_endpoint(_T("gameserverds"), m_appConfig),
-#if TV_API
-        _T("/qosservers"),
-#else
-        _T("/xplatqosservers"),
-#endif
+		path,
         xbox_live_api::get_quality_of_service_servers
         );
 

--- a/Source/Services/GameServerPlatform/game_server_platform_service.cpp
+++ b/Source/Services/GameServerPlatform/game_server_platform_service.cpp
@@ -253,27 +253,13 @@ game_server_platform_service::get_game_server_metadata(
 pplx::task<xbox::services::xbox_live_result<std::vector<quality_of_service_server>>>
 game_server_platform_service::get_quality_of_service_servers()
 {
-
-	string_t path;
-	
-	if (m_xboxLiveContextSettings)
-	{
-		path = m_xboxLiveContextSettings->use_crossplatform_qos_servers() ? _T("/xplatqosservers") : _T("/qosservers");
-	}
-	else
-	{
-#if TV_API
-		path = _T("/qosservers");
-#else
-		path = _T("/xplatqosservers");
-#endif
-	}
+    const string_t path = m_xboxLiveContextSettings->use_crossplatform_qos_servers() ? _T("/xplatqosservers") : _T("/qosservers");
 
     std::shared_ptr<http_call> httpCall = xbox::services::system::xbox_system_factory::get_factory()->create_http_call(
         m_xboxLiveContextSettings,
         _T("GET"),
         utils::create_xboxlive_endpoint(_T("gameserverds"), m_appConfig),
-		path,
+        path,
         xbox_live_api::get_quality_of_service_servers
         );
 

--- a/Source/Shared/xbox_live_context_settings.cpp
+++ b/Source/Shared/xbox_live_context_settings.cpp
@@ -66,6 +66,11 @@ xbox_live_context_settings::xbox_live_context_settings() :
     m_httpRetryDelay(std::chrono::seconds(DEFAULT_RETRY_DELAY_SECONDS)),
     m_httpTimeoutWindow(std::chrono::seconds(DEFAULT_HTTP_RETRY_WINDOW_SECONDS)),
     m_useCoreDispatcherForEventRouting(false)
+#if TV_API
+	m_useXplatQosServer(false)
+#else
+	m_useXplatQosServer(true)
+#endif
 {
 }
 
@@ -218,6 +223,16 @@ void xbox_live_context_settings::disable_asserts_for_maximum_number_of_websocket
     )
 {
     xbox_live_app_config_internal::get_app_config_singleton()->disable_asserts_for_maximum_number_of_websockets_activated(setting);
+}
+
+bool xbox_live_context_settings::use_crossplatform_qos_servers() const
+{
+	return m_useXplatQosServer;
+}
+
+void xbox_live_context_settings::set_use_crossplatform_qos_servers(_In_ bool value)
+{
+	m_useXplatQosServer = value;
 }
 
 NAMESPACE_MICROSOFT_XBOX_SERVICES_CPP_END

--- a/Source/Shared/xbox_live_context_settings.cpp
+++ b/Source/Shared/xbox_live_context_settings.cpp
@@ -65,11 +65,11 @@ xbox_live_context_settings::xbox_live_context_settings() :
     m_websocketTimeoutWindow(std::chrono::seconds(DEFAULT_WEBSOCKET_TIMEOUT_SECONDS)),
     m_httpRetryDelay(std::chrono::seconds(DEFAULT_RETRY_DELAY_SECONDS)),
     m_httpTimeoutWindow(std::chrono::seconds(DEFAULT_HTTP_RETRY_WINDOW_SECONDS)),
-    m_useCoreDispatcherForEventRouting(false)
+    m_useCoreDispatcherForEventRouting(false),
 #if TV_API
-	m_useXplatQosServer(false)
+    m_useXplatQosServer(false)
 #else
-	m_useXplatQosServer(true)
+    m_useXplatQosServer(true)
 #endif
 {
 }
@@ -227,12 +227,12 @@ void xbox_live_context_settings::disable_asserts_for_maximum_number_of_websocket
 
 bool xbox_live_context_settings::use_crossplatform_qos_servers() const
 {
-	return m_useXplatQosServer;
+    return m_useXplatQosServer;
 }
 
 void xbox_live_context_settings::set_use_crossplatform_qos_servers(_In_ bool value)
 {
-	m_useXplatQosServer = value;
+    m_useXplatQosServer = value;
 }
 
 NAMESPACE_MICROSOFT_XBOX_SERVICES_CPP_END


### PR DESCRIPTION
Forewords : It is a proposal and I do not have a strong opinion about how it should be done. 

The need is to be able to select the qos server at runtime without modifying the library (so having to compile and maintain a custom change in qos server selection). This change is necessary usually on Xbox target to be able to use the insecure (or crossplatform as called in the codebase) qos endpoint. 

I am exposing here in the live context setting a new flag that let know the gameserver service which endpoint to use.

Let me know what you think.