### PR TITLE
Fix null value used for CppRestSDK json::value

### DIFF
--- a/Source/Services/EntertainmentProfile/entertainment_profile_list_xbox_one_pins.cpp
+++ b/Source/Services/EntertainmentProfile/entertainment_profile_list_xbox_one_pins.cpp
@@ -118,7 +118,7 @@ pplx::task<xbox::services::xbox_live_result<void>> entertainment_profile_list_xb
     web::json::value item;
     if(providerId.empty())
     {
-        item[_T("ProviderId")] = web::json::value::Null;
+        item[_T("ProviderId")] = web::json::value::null();
     }
     else
     {
@@ -165,7 +165,7 @@ pplx::task<xbox::services::xbox_live_result<entertainment_profile_list_contains_
     web::json::value item;
     if(providerId.empty())
     {
-        item[_T("ProviderId")] = web::json::value::Null;
+        item[_T("ProviderId")] = web::json::value::null();
     }
     else
     {


### PR DESCRIPTION
The null value for a `web::json::value` was incorrectly set using the
enum `web::json::value::NULL` rather than `web::json::value::null()`.
This will lead to the value being the numeric value of the enum,
rather than the intended 'null'.