### PR TITLE
Remove the virtual dtor from social_manager

### DIFF
--- a/Include/xsapi/social_manager.h
+++ b/Include/xsapi/social_manager.h
@@ -769,8 +769,6 @@ private:
 class social_manager : public std::enable_shared_from_this<social_manager>
 {
 public:
-    virtual ~social_manager() {}
-
     /// <summary>
     /// Gets the social_manager singleton instance
     /// </summary>


### PR DESCRIPTION
std::enable_shared_from_this does not require a virtual destructor. std::make_shared will choose the correct dtor to use.